### PR TITLE
Refactor decoder

### DIFF
--- a/sherpa-ncnn/csrc/decoder.h
+++ b/sherpa-ncnn/csrc/decoder.h
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c)  2022  Xiaomi Corporation (authors: Fangjun Kuang)
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHERPA_NCNN_CSRC_DECODER_H_
+#define SHERPA_NCNN_CSRC_DECODER_H_
+
+#include "sherpa_ncnn/csrc/hypothesis.h"
+#include "sherpa_ncnn/csrc/model.h"
+
+namespace sherpa_ncnn {
+
+struct RecognitionResult {
+  // For greedy search
+  //   (1) GetInitialResult() initializes it to [blank]*context_size
+  //   (2) GetFinalResult() will strip the leading [blank]*context_size
+  //
+  // For modified_beam_search,
+  //   (1) GetInitialResult() leaves it as-is.
+  //   (2) GetFinalResult() will fill it with the best result from hyps.
+  std::vector<int32_t> tokens;
+
+  // used only for modified_beam_search
+  Hypotheses hyps;
+};
+
+struct DecoderConfig {
+  // Supported values at present: greedy_search
+  std::string method = "greedy_search";
+
+  int32_t num_active_paths = 4;  // for modified beam search
+};
+
+class Decoder {
+ public:
+  Decoder(const DecoderConfig &config, Model *model);
+  virtual ~Decoder() = default;
+
+  /**
+   * For greedy search, it initializes `ret.tokens` to `[blank] * context_size`.
+   * For modified beam search, it initializes `ret.hyps` to contain a single
+   * hypothesis with value `[blank] * context_size`.
+   */
+  virtual RecognitionResult GetInitialResult() const = 0;
+
+  /**
+   * For greedy search, it strips the leading blanks from `r.tokens`.
+   * For modified_beam_search, it gets the best result from `hyps` and
+   * set `ret.tokens`.
+   */
+  virtual RecognitionResult GetFinalResult(
+      const RecognitionResult &r) const = 0;
+
+  virtual void Decode(ncnn::Mat &encoder_out, RecognitionResult *result) = 0;
+};
+
+}  // namespace sherpa_ncnn
+#endif  // SHERPA_NCNN_CSRC_DECODER_H_

--- a/sherpa-ncnn/csrc/hypothesis.cc
+++ b/sherpa-ncnn/csrc/hypothesis.cc
@@ -1,0 +1,58 @@
+/**
+ * Copyright      2022  Xiaomi Corporation (authors: Fangjun Kuang)
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sherpa_ncnn/csrc/hypothesis.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "sherpa_ncnn/csrc/math.h"
+
+namespace sherpa_ncnn {
+
+void Hypotheses::Add(Hypothesis hyp) {
+  auto key = hyp.Key();
+  auto it = hyps_dict_.find(key);
+  if (it == hyps_dict_.end()) {
+    hyps_dict_[key] = std::move(hyp);
+  } else {
+    it->second.log_prob = LogAdd<double>()(it->second.log_prob, hyp.log_prob);
+  }
+}
+
+Hypothesis Hypotheses::GetMostProbable(bool length_norm) const {
+  if (length_norm == false) {
+    return std::max_element(hyps_dict_.begin(), hyps_dict_.end(),
+                            [](const auto &left, auto &right) -> bool {
+                              return left.second.log_prob <
+                                     right.second.log_prob;
+                            })
+        ->second;
+  } else {
+    // for length_norm is true
+    return std::max_element(
+               hyps_dict_.begin(), hyps_dict_.end(),
+               [](const auto &left, const auto &right) -> bool {
+                 return left.second.log_prob / left.second.ys.size() <
+                        right.second.log_prob / right.second.ys.size();
+               })
+        ->second;
+  }
+}
+
+}  // namespace sherpa_ncnn

--- a/sherpa-ncnn/csrc/hypothesis.h
+++ b/sherpa-ncnn/csrc/hypothesis.h
@@ -1,0 +1,126 @@
+/**
+ * Copyright      2022  Xiaomi Corporation (authors: Fangjun Kuang)
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHERPA_NCNN_CSRC_HYPOTHESIS_H_
+#define SHERPA_NCNN_CSRC_HYPOTHESIS_H_
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace sherpa_ncnn {
+
+struct Hypothesis {
+  // The predicted tokens so far. Newly predicated tokens are appended.
+  std::vector<int32_t> ys;
+
+  // timestamps[i] contains the frame number after subsampling
+  // on which ys[i] is decoded.
+  std::vector<int32_t> timestamps;
+
+  // The total score of ys in log space.
+  double log_prob = 0;
+
+  int32_t num_trailing_blanks = 0;
+
+  Hypothesis() = default;
+  Hypothesis(const std::vector<int32_t> &ys, double log_prob)
+      : ys(ys), log_prob(log_prob) {}
+
+  // If two Hypotheses have the same `Key`, then they contain
+  // the same token sequence.
+  std::string Key() const {
+    // TODO(fangjun): Use a hash function?
+    std::ostringstream os;
+    std::string sep = "-";
+    for (auto i : ys) {
+      os << i << sep;
+      sep = "-";
+    }
+    return os.str();
+  }
+
+  // For debugging
+  std::string ToString() const {
+    std::ostringstream os;
+    os << "(" << Key() << ", " << log_prob << ")";
+    return os.str();
+  }
+};
+
+class Hypotheses {
+ public:
+  Hypotheses() = default;
+
+  explicit Hypotheses(std::vector<Hypothesis> hyps) {
+    for (auto &h : hyps) {
+      hyps_dict_[h.Key()] = std::move(h);
+    }
+  }
+
+  explicit Hypotheses(std::unordered_map<std::string, Hypothesis> hyps_dict)
+      : hyps_dict_(std::move(hyps_dict)) {}
+
+  // Add hyp to this object. If it already exists, its log_prob
+  // is updated with the given hyp using log-sum-exp.
+  void Add(Hypothesis hyp);
+
+  // Get the hyp that has the largest log_prob.
+  // If length_norm is true, hyp's log_prob are divided by
+  // len(hyp.ys) before comparison.
+  Hypothesis GetMostProbable(bool length_norm) const;
+
+  // Remove the given hyp from this object.
+  // It is *NOT* an error if hyp does not exist in this object.
+  void Remove(const Hypothesis &hyp) { hyps_dict_.erase(hyp.Key()); }
+
+  // Return a list of hyps contained in this object.
+  std::vector<Hypothesis> Vec() const {
+    std::vector<Hypothesis> ans;
+    ans.reserve(hyps_dict_.size());
+    for (const auto &p : hyps_dict_) {
+      ans.push_back(p.second);
+    }
+    return ans;
+  }
+
+  int32_t Size() const { return hyps_dict_.size(); }
+
+  std::string ToString() const {
+    std::ostringstream os;
+    for (const auto &p : hyps_dict_) {
+      os << p.second.ToString() << "\n";
+    }
+    return os.str();
+  }
+
+  auto begin() { return hyps_dict_.begin(); }
+  auto end() { return hyps_dict_.end(); }
+
+  const auto begin() const { return hyps_dict_.begin(); }
+  const auto end() const { return hyps_dict_.end(); }
+
+ private:
+  using Map = std ::unordered_map<std::string, Hypothesis>;
+  Map hyps_dict_;
+};
+
+}  // namespace sherpa_ncnn
+
+#endif  // SHERPA_NCNN_CSRC_HYPOTHESIS_H_

--- a/sherpa-ncnn/csrc/math.h
+++ b/sherpa-ncnn/csrc/math.h
@@ -1,0 +1,83 @@
+/**
+ * Copyright      2022  Xiaomi Corporation (authors: Daniel Povey)
+ *
+ * See LICENSE for clarification regarding multiple authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// This file is copied from k2/csrc/utils.h
+#ifndef SHERPA_NCNN_CSRC_MATH_H_
+#define SHERPA_NCNN_CSRC_MATH_H_
+
+#include <cmath>
+
+namespace sherpa_ncnn {
+
+// logf(FLT_EPSILON)
+#define SHERPA_NCNN_MIN_LOG_DIFF_FLOAT -15.9423847198486328125f
+
+// log(DBL_EPSILON)
+#define SHERPA_NCNN_MIN_LOG_DIFF_DOUBLE \
+  -36.0436533891171535515240975655615329742431640625
+
+template <typename T>
+struct LogAdd;
+
+template <>
+struct LogAdd<double> {
+  double operator()(double x, double y) const {
+    double diff;
+
+    if (x < y) {
+      diff = x - y;
+      x = y;
+    } else {
+      diff = y - x;
+    }
+    // diff is negative.  x is now the larger one.
+
+    if (diff >= SHERPA_NCNN_MIN_LOG_DIFF_DOUBLE) {
+      double res;
+      res = x + log1p(exp(diff));
+      return res;
+    }
+
+    return x;  // return the larger one.
+  }
+};
+
+template <>
+struct LogAdd<float> {
+  float operator()(float x, float y) const {
+    float diff;
+
+    if (x < y) {
+      diff = x - y;
+      x = y;
+    } else {
+      diff = y - x;
+    }
+    // diff is negative.  x is now the larger one.
+
+    if (diff >= SHERPA_NCNN_MIN_LOG_DIFF_DOUBLE) {
+      float res;
+      res = x + log1pf(expf(diff));
+      return res;
+    }
+
+    return x;  // return the larger one.
+  }
+};
+
+}  // namespace sherpa_ncnn
+#endif  // SHERPA_NCNN_CSRC_MATH_H_


### PR DESCRIPTION
This PR only defines the interface for the decoder.

Please have a look at
- https://github.com/k2-fsa/sherpa/blob/master/sherpa/csrc/online-transducer-decoder.h
- https://github.com/k2-fsa/sherpa/blob/master/sherpa/csrc/online-transducer-greedy-search-decoder.cc
- https://github.com/k2-fsa/sherpa/blob/master/sherpa/csrc/online-transducer-modified-beam-search-decoder.cc


## TODOs
- [ ] Rename `decode.h` and `decode.cc` to `greedy-search-decoder.h` and `greedy-search-decoder.cc` and create a class `GreedySearchDecoder` inheriting from `Decoder` and implement the abstract methods
- [ ] Implement a function to compute log_softmax
- [ ] Implement `ModifiedBeamSearchDecoder`

Note: Since `ncnn` supports only `batch_size == 1`,  so we only need to consider the case of decoding a single utterance
and we don't need to introduce k2 as a dependency to implement modified beam search.