### PR TITLE
Publish pre-built wheels to PyPI

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - wheel
+      - build-wheel-2023-01-09
     tags:
       - '*'
 
@@ -32,7 +33,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
-          CIBW_SKIP: "cp27-* cp35-* *-win32"
+          CIBW_SKIP: "cp27-* cp35-* *-win32 pp*"
           CIBW_BUILD_VERBOSITY: 3
 
       - name: Display wheels

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - wheel
-      - build-wheel-2023-01-09
     tags:
       - '*'
 
@@ -55,4 +54,4 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install wheel twine setuptools
 
-          twine upload ./wheels/*.whl
+          twine upload ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v1.12.0
+        uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
           CIBW_SKIP: "cp27-* cp35-* *-win32"
@@ -44,3 +44,10 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+
+      - name: Publish wheels to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          twine upload ./wheels/*.whl

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
-          CIBW_SKIP: "cp27-* cp35-* *-win32 pp* *-muslinux*"
+          CIBW_SKIP: "cp27-* cp35-* *-win32 pp* *-musllinux*"
           CIBW_BUILD_VERBOSITY: 3
 
       - name: Display wheels

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - wheel
-      - build-wheels-2023-01-09
+      - build-wheel-2023-01-09
     tags:
       - '*'
 

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -1,0 +1,46 @@
+name: build-wheels
+
+on:
+  push:
+    branches:
+      - wheel
+      - build-wheels-2023-01-09
+    tags:
+      - '*'
+
+env:
+  SHERPA_NCNN_IS_IN_GITHUB_ACTIONS: 1
+
+concurrency:
+  group: build-wheels-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v1.12.0
+        env:
+          CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
+          CIBW_SKIP: "cp27-* cp35-* *-win32"
+          CIBW_BUILD_VERBOSITY: 3
+
+      - name: Display wheels
+        shell: bash
+        run: |
+          ls -lh ./wheelhouse/
+
+          ls -lh ./wheelhouse/*.whl
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.4
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
-          CIBW_SKIP: "cp27-* cp35-* *-win32 pp*"
+          CIBW_SKIP: "cp27-* cp35-* *-win32 pp* *-muslinux*"
           CIBW_BUILD_VERBOSITY: 3
 
       - name: Display wheels
@@ -52,4 +52,7 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install wheel twine setuptools
+
           twine upload ./wheels/*.whl

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - wheel
-      - build-wheel-2023-01-09
     tags:
       - '*'
 
@@ -27,6 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
+      # for a list of versions
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.4
         env:


### PR DESCRIPTION
Some users have difficulties in installing `sherpa-ncnn` with `pip install sherpa-ncnn` since they either don't have `cmake` or they don't have a C++ compiler.

To fix that, we upload pre-built wheels to PyPI.

Currently, the following OS on x86 are supported:
- Linux
- macOS
- Windows

Will add support for arm and aarch64.