### PR TITLE
add verbose output if it's unable to create a model

### DIFF
--- a/sherpa-ncnn/csrc/model.cc
+++ b/sherpa-ncnn/csrc/model.cc
@@ -125,6 +125,15 @@ std::unique_ptr<Model> Model::Create(const ModelConfig &config) {
     return std::make_unique<ConvEmformerModel>(config);
   }
 
+  NCNN_LOGE(
+      "Unable to create a model from specified model files.\n"
+      "Please check: \n"
+      "  1. If you are using a ConvEmformer model, please make sure you have "
+      "added SherapMetaData to encoder_xxx.ncnn.param "
+      "(or encoder_xxx.ncnn.int8.param if you are using an int8 model). "
+      "You need to add it manually after converting the model with pnnx.\n"
+      "  2. (Android) Whether the app requires an int8 model or not\n");
+
   return nullptr;
 }
 
@@ -147,6 +156,15 @@ std::unique_ptr<Model> Model::Create(AAssetManager *mgr,
   if (IsConvEmformerModel(net)) {
     return std::make_unique<ConvEmformerModel>(mgr, config);
   }
+
+  NCNN_LOGE(
+      "Unable to create a model from specified model files.\n"
+      "Please check: \n"
+      "  1. If you are using a ConvEmformer model, please make sure you have "
+      "added SherapMetaData to encoder_xxx.ncnn.param "
+      "(or encoder_xxx.ncnn.int8.param if you are using an int8 model). "
+      "You need to add it manually after converting the model with pnnx.\n"
+      "  2. (Android) Whether the app requires an int8 model or not\n");
 
   return nullptr;
 }


### PR DESCRIPTION
The master branch throws a segfault on error, which is not informative. This PR prints more verbose output on errors.