### PR TITLE
Fix building for iOS

### DIFF
--- a/ios-swift/SherpaNcnn/SherpaNcnn.xcodeproj/project.pbxproj
+++ b/ios-swift/SherpaNcnn/SherpaNcnn.xcodeproj/project.pbxproj
@@ -512,6 +512,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.k2-fsa.org.SherpaNcnn";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
To fix the following error in Release build for simulator:
```
ld: in /Users/fangjun/open-source/sherpa-ncnn/build-ios/sherpa-ncnn.framework/sherpa-ncnn(allocator.cpp.o), building for iOS Simulator, but linking in object file built for iOS, file '/Users/fangjun/open-source/sherpa-ncnn/build-ios/sherpa-ncnn.framework/sherpa-ncnn' for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Change `No` to `Yes` in the following screenshot:

![Screenshot 2023-01-29 at 12 10 38](https://user-images.githubusercontent.com/5284924/215304494-e91ed6ab-26a4-4892-85ec-186b86657eca.png)
