### PR TITLE
support timestamps

### DIFF
--- a/sherpa-ncnn/csrc/greedy-search-decoder.cc
+++ b/sherpa-ncnn/csrc/greedy-search-decoder.cc
@@ -38,6 +38,7 @@ void GreedySearchDecoder::BuildDecoderInput() {
 void GreedySearchDecoder::ResetResult() {
   result_.tokens.clear();
   result_.text.clear();
+  result_.timestamps.clear();
   result_.num_trailing_blanks = 0;
   for (int32_t i = 0; i != context_size_; ++i) {
     result_.tokens.push_back(blank_id_);
@@ -63,6 +64,7 @@ void GreedySearchDecoder::Decode() {
       if (new_token != blank_id_) {
         result_.tokens.push_back(new_token);
         result_.text += (*sym_)[new_token];
+        result_.timestamps.push_back(static_cast<float>(t + num_processed_));
         BuildDecoderInput();
         decoder_out_ = model_->RunDecoder(decoder_input_);
         result_.num_trailing_blanks = 0;

--- a/sherpa-ncnn/csrc/hypothesis.h
+++ b/sherpa-ncnn/csrc/hypothesis.h
@@ -33,7 +33,7 @@ struct Hypothesis {
 
   // timestamps[i] contains the frame number after subsampling
   // on which ys[i] is decoded.
-  std::vector<int32_t> timestamps;
+  std::vector<float> timestamps;
 
   // The total score of ys in log space.
   double log_prob = 0;

--- a/sherpa-ncnn/csrc/modified-beam-search-decoder.cc
+++ b/sherpa-ncnn/csrc/modified-beam-search-decoder.cc
@@ -168,6 +168,7 @@ void ModifiedBeamSearchDecoder::Decode() {
 
         if (new_token != blank_id_) {
           new_hyp.ys.push_back(new_token);
+          new_hyp.timestamps.push_back(static_cast<float>(t + num_processed_));
           new_hyp.num_trailing_blanks = 0;
         } else {
           ++new_hyp.num_trailing_blanks;
@@ -192,6 +193,7 @@ RecognitionResult ModifiedBeamSearchDecoder::GetResult() {
     }
   }
   result_.text = std::move(best_hyp_text);
+  result_.timestamps = best_hyp.timestamps;
   result_.num_trailing_blanks = best_hyp.num_trailing_blanks;
   auto ans = result_;
 

--- a/sherpa-ncnn/csrc/recognizer.cc
+++ b/sherpa-ncnn/csrc/recognizer.cc
@@ -94,7 +94,7 @@ RecognitionResult Recognizer::GetResult() {
     t *= frame_shift_s;
   }
 
-  return std::move(r);
+  return r;
 }
 
 bool Recognizer::IsEndpoint() { return decoder_->IsEndpoint(); }

--- a/sherpa-ncnn/csrc/recognizer.h
+++ b/sherpa-ncnn/csrc/recognizer.h
@@ -32,15 +32,28 @@
 
 namespace sherpa_ncnn {
 
-// TODO(fangjun): Add timestamps
 struct RecognitionResult {
   std::vector<int32_t> tokens;
   std::string text;
+  std::vector<float> timestamps;
 
   int32_t num_trailing_blanks = 0;
 
   // used only for modified_beam_search
   Hypotheses hyps;
+
+  std::string ToString() const {
+    std::ostringstream os;
+
+    os << "text: " << text << "\n";
+    os << "timestamps: ";
+    for (const auto & t : timestamps) {
+      os << t << " ";
+    }
+    os << "\n";
+
+    return os.str();
+  }
 };
 
 struct DecoderConfig {
@@ -114,6 +127,7 @@ class Recognizer {
 
  private:
   std::unique_ptr<Model> model_;
+  std::unique_ptr<knf::FbankOptions> fbank_opts_;
   std::unique_ptr<SymbolTable> sym_;
   std::unique_ptr<Endpoint> endpoint_;
   std::unique_ptr<Decoder> decoder_;

--- a/sherpa-ncnn/csrc/sherpa-ncnn.cc
+++ b/sherpa-ncnn/csrc/sherpa-ncnn.cc
@@ -113,7 +113,7 @@ for a list of pre-trained models to download.
   std::cout << "Done!\n";
 
   std::cout << "Recognition result for " << wav_filename << "\n"
-            << result.text << "\n";
+            << result.ToString();
 
   auto end = std::chrono::steady_clock::now();
   float elapsed_seconds =


### PR DESCRIPTION
hi, our project need timestamps with sherpa-ncnn, current sherpa-ncnn has no timestamps output,  I have completed this. But also has some confusions:
1. [sherpa-ncnn-alsa.cc](https://github.com/k2-fsa/sherpa-ncnn/blob/master/sherpa-ncnn/csrc/sherpa-ncnn-alsa.cc) and [sherpa-ncnn-microphone.cc](https://github.com/k2-fsa/sherpa-ncnn/blob/master/sherpa-ncnn/csrc/sherpa-ncnn-microphone.cc) need to print timestamps result
2. https://github.com/xiangxyq/sherpa-ncnn/blob/cj-add-timestamps/sherpa-ncnn/csrc/recognizer.h#L38 
timestamps use float instead int32, if use Convert like sherpa https://github.com/k2-fsa/sherpa/blob/4756d4ec10c61164eff356190740527993844df3/sherpa/cpp_api/online-stream.h#L17 ,  need extra struct
4. https://github.com/xiangxyq/sherpa-ncnn/blob/28b77f7f6f1820fb0149530b5ef5c933b7275fb2/sherpa-ncnn/csrc/greedy-search-decoder.cc#L43 , here why  push blanck_id to token, how to handle timestamps?  this question also in https://github.com/k2-fsa/sherpa-ncnn/blob/b80b74695be0eafcc7a3815a5647899b7b9a82b5/sherpa-ncnn/csrc/modified-beam-search-decoder.cc#L120

Thanks!