### PR TITLE
Update python example for streaming recognition.

### DIFF
--- a/sherpa-ncnn/python/sherpa_ncnn/recognizer.py
+++ b/sherpa-ncnn/python/sherpa_ncnn/recognizer.py
@@ -91,6 +91,7 @@ class Recognizer(object):
         rule2_min_trailing_silence: int = 1.2,
         rule3_min_utterance_length: int = 20,
         max_feature_vectors: int = -1,
+        model_sample_rate: int = 16000,
     ):
         """
         Please refer to
@@ -144,6 +145,8 @@ class Recognizer(object):
           max_feature_vectors:
             It specifies the number of feature frames to cache. Use -1
             to cache all processed frames
+          model_sample_rate:
+            Sample rate expected by the model
         """
         _assert_file_exists(tokens)
         _assert_file_exists(encoder_param)
@@ -159,7 +162,7 @@ class Recognizer(object):
             "modified_beam_search",
         ), decoding_method
         feat_config = FeatureExtractorConfig(
-            sampling_rate=16000,
+            sampling_rate=model_sample_rate,
             feature_dim=80,
             max_feature_vectors=-1,
         )
@@ -204,12 +207,13 @@ class Recognizer(object):
 
         Args:
           sample_rate:
-            Sample rate of the input audio samples. It should be 16000.
+            Sample rate of the input audio samples. You must use the same
+            value across different calls to `accept_waveform`! If it
+            is different from self.sample_rate, we will do resampling inside.
           waveform:
             A 1-D float32 array containing audio samples in the
             range ``[-1, 1]``.
         """
-        assert sample_rate == self.sample_rate, (sample_rate, self.sample_rate)
         self.stream.accept_waveform(sample_rate, waveform)
         self._decode()
 


### PR DESCRIPTION
Also, we don't require wave_file.sample_rate == recognizer.sample_rate. If they are different, we will do resampling inside sherpa-ncnn.