### PR TITLE
Add alternative URLs for cmake dependencies.

### DIFF
--- a/cmake/kaldi-native-fbank.cmake
+++ b/cmake/kaldi-native-fbank.cmake
@@ -3,6 +3,7 @@ function(download_kaldi_native_fbank)
 
   # Please also change ../pack-for-embedded-systems.sh
   set(kaldi_native_fbank_URL  "https://github.com/csukuangfj/kaldi-native-fbank/archive/refs/tags/v1.12.tar.gz")
+  set(kaldi_native_fbank_URL2 "https://huggingface.co/csukuangfj/sherpa-ncnn-cmake-deps/resolve/main/kaldi-native-fbank-1.12.tar.gz")
   set(kaldi_native_fbank_HASH "SHA256=8f4dfc3f6ddb1adcd9ac0ae87743ebc6cbcae147aacf9d46e76fa54134e12b44")
 
   # If you don't have access to the Internet, please download it to your
@@ -27,7 +28,9 @@ function(download_kaldi_native_fbank)
   set(KALDI_NATIVE_FBANK_ENABLE_CHECK OFF CACHE BOOL "" FORCE)
 
   FetchContent_Declare(kaldi_native_fbank
-    URL               ${kaldi_native_fbank_URL}
+    URL
+      ${kaldi_native_fbank_URL}
+      ${kaldi_native_fbank_URL2}
     URL_HASH          ${kaldi_native_fbank_HASH}
   )
 

--- a/cmake/ncnn.cmake
+++ b/cmake/ncnn.cmake
@@ -6,7 +6,8 @@ function(download_ncnn)
   # https://github.com/csukuangfj/ncnn/pull/7
 
   # Please also change ../pack-for-embedded-systems.sh
-  set(ncnn_URL "https://github.com/csukuangfj/ncnn/archive/refs/tags/sherpa-0.9.tar.gz")
+  set(ncnn_URL  "https://github.com/csukuangfj/ncnn/archive/refs/tags/sherpa-0.9.tar.gz")
+  set(ncnn_URL2 "https://huggingface.co/csukuangfj/sherpa-ncnn-cmake-deps/resolve/main/ncnn-sherpa-0.9.tar.gz")
   set(ncnn_HASH "SHA256=a5fe1f69c75c06d6de858c7c660c43395b6ed3df9ee59d6e2fe621211e6928cd")
 
   # If you don't have access to the Internet, please download it to your
@@ -27,7 +28,9 @@ function(download_ncnn)
   endforeach()
 
   FetchContent_Declare(ncnn
-    URL               ${ncnn_URL}
+    URL
+      ${ncnn_URL}
+      ${ncnn_URL2}
     URL_HASH          ${ncnn_HASH}
   )
 

--- a/cmake/portaudio.cmake
+++ b/cmake/portaudio.cmake
@@ -2,6 +2,7 @@ function(download_portaudio)
   include(FetchContent)
 
   set(portaudio_URL  "http://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz")
+  set(portaudio_URL2 "https://huggingface.co/csukuangfj/sherpa-ncnn-cmake-deps/resolve/main/pa_stable_v190700_20210406.tgz")
   set(portaudio_HASH "SHA256=47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def")
 
   # If you don't have access to the Internet, please download it to your
@@ -30,7 +31,9 @@ function(download_portaudio)
   endif()
 
   FetchContent_Declare(portaudio
-    URL               ${portaudio_URL}
+    URL
+      ${portaudio_URL}
+      ${portaudio_URL2}
     URL_HASH          ${portaudio_HASH}
   )
 

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -2,6 +2,7 @@ function(download_pybind11)
   include(FetchContent)
 
   set(pybind11_URL  "https://github.com/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz")
+  set(pybind11_URL2 "https://huggingface.co/csukuangfj/sherpa-ncnn-cmake-deps/resolve/main/pybind11-2.10.2.tar.gz")
   set(pybind11_HASH "SHA256=93bd1e625e43e03028a3ea7389bba5d3f9f2596abc074b068e70f4ef9b1314ae")
 
   # If you don't have access to the Internet, please download it to your
@@ -22,7 +23,9 @@ function(download_pybind11)
   endforeach()
 
   FetchContent_Declare(pybind11
-    URL               ${pybind11_URL}
+    URL
+      ${pybind11_URL}
+      ${pybind11_URL2}
     URL_HASH          ${pybind11_HASH}
   )
 


### PR DESCRIPTION
People from China have difficulty downloading cmake dependencies while installing sherpa-ncnn. This commit adds alternative URLs for downloading deps.