### PR TITLE
Support cmake for ffmpeg-examples.

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -65,7 +65,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -D CMAKE_BUILD_TYPE=Release ..
+          cmake -D CMAKE_BUILD_TYPE=Release -DSHERPA_NCNN_ENABLE_FFMPEG_EXAMPLES=ON ..
 
       - name: Build sherpa for ubuntu
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,9 @@ encoder-scale-table.txt
 joiner-scale-table.txt
 *.tar.gz
 generate-int8-*.sh
+
+# For JetBrains IDE Clion.
+.idea
+cmake-build-release
+cmake-build-debug
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option(SHERPA_NCNN_ENABLE_BINARY "Whether to build the binary sherpa-ncnn" ON)
 option(SHERPA_NCNN_ENABLE_TEST "Whether to build tests" OFF)
 option(SHERPA_NCNN_ENABLE_C_API "Whether to build C API" ON)
 option(SHERPA_NCNN_ENABLE_GENERATE_INT8_SCALE_TABLE "Whether to generate-int8-scale-table" ON)
+option(SHERPA_NCNN_ENABLE_FFMPEG_EXAMPLES "Whether enable ffmpeg-examples" OFF)
 
 if(DEFINED ANDROID_ABI)
   message(STATUS "Set SHERPA_NCNN_ENABLE_JNI to ON for Android")
@@ -57,6 +58,7 @@ message(STATUS "SHERPA_NCNN_ENABLE_BINARY ${SHERPA_NCNN_ENABLE_BINARY}")
 message(STATUS "SHERPA_NCNN_ENABLE_TEST ${SHERPA_NCNN_ENABLE_TEST}")
 message(STATUS "SHERPA_NCNN_ENABLE_C_API ${SHERPA_NCNN_ENABLE_C_API}")
 message(STATUS "SHERPA_NCNN_ENABLE_GENERATE_INT8_SCALE_TABLE ${SHERPA_NCNN_ENABLE_GENERATE_INT8_SCALE_TABLE}")
+message(STATUS "SHERPA_NCNN_ENABLE_FFMPEG_EXAMPLES ${SHERPA_NCNN_ENABLE_FFMPEG_EXAMPLES}")
 
 if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "No CMAKE_BUILD_TYPE given, default to Release")
@@ -114,6 +116,10 @@ if(SHERPA_NCNN_ENABLE_PYTHON)
 endif()
 
 add_subdirectory(sherpa-ncnn)
+
+if(SHERPA_NCNN_ENABLE_FFMPEG_EXAMPLES)
+  add_subdirectory(ffmpeg-examples)
+endif()
 
 if(SHERPA_NCNN_ENABLE_C_API AND SHERPA_NCNN_ENABLE_BINARY)
   add_subdirectory(c-api-examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ option(SHERPA_NCNN_ENABLE_BINARY "Whether to build the binary sherpa-ncnn" ON)
 option(SHERPA_NCNN_ENABLE_TEST "Whether to build tests" OFF)
 option(SHERPA_NCNN_ENABLE_C_API "Whether to build C API" ON)
 option(SHERPA_NCNN_ENABLE_GENERATE_INT8_SCALE_TABLE "Whether to generate-int8-scale-table" ON)
-option(SHERPA_NCNN_ENABLE_FFMPEG_EXAMPLES "Whether enable ffmpeg-examples" OFF)
+option(SHERPA_NCNN_ENABLE_FFMPEG_EXAMPLES "Whether to enable ffmpeg-examples" OFF)
 
 if(DEFINED ANDROID_ABI)
   message(STATUS "Set SHERPA_NCNN_ENABLE_JNI to ON for Android")

--- a/ffmpeg-examples/CMakeLists.txt
+++ b/ffmpeg-examples/CMakeLists.txt
@@ -1,0 +1,22 @@
+
+include_directories(${CMAKE_SOURCE_DIR})
+add_executable(sherpa-ncnn-ffmpeg sherpa-ncnn-ffmpeg.cc)
+target_link_libraries(sherpa-ncnn-ffmpeg pthread m)
+
+# Link libraries from sherpa-ncnn.
+target_link_libraries(sherpa-ncnn-ffmpeg sherpa-ncnn-c-api sherpa-ncnn-core kaldi-native-fbank-core ncnn)
+if(BUILD_SHARED_LIBS)
+    target_link_libraries(sherpa-ncnn-ffmpeg "portaudio")
+else()
+    target_link_libraries(sherpa-ncnn-ffmpeg "portaudio_static")
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(AVCODEC REQUIRED libavcodec)
+include_directories(${AVCODEC_INCLUDE_DIRS})
+target_link_directories(sherpa-ncnn-ffmpeg PRIVATE ${AVCODEC_LIBRARY_DIRS})
+target_link_libraries(sherpa-ncnn-ffmpeg ${AVCODEC_LIBRARIES})
+# All libraries of FFmpeg shares the same include and library directory.
+# Note that ${AVCODEC_LIBRARIES} equals to avcodec, but we add it for consistence.
+target_link_libraries(sherpa-ncnn-ffmpeg avcodec avformat avfilter avutil swresample swscale avdevice)
+

--- a/ffmpeg-examples/CMakeLists.txt
+++ b/ffmpeg-examples/CMakeLists.txt
@@ -1,15 +1,9 @@
 
 include_directories(${CMAKE_SOURCE_DIR})
 add_executable(sherpa-ncnn-ffmpeg sherpa-ncnn-ffmpeg.cc)
-target_link_libraries(sherpa-ncnn-ffmpeg pthread m)
 
 # Link libraries from sherpa-ncnn.
-target_link_libraries(sherpa-ncnn-ffmpeg sherpa-ncnn-c-api sherpa-ncnn-core kaldi-native-fbank-core ncnn)
-if(BUILD_SHARED_LIBS)
-    target_link_libraries(sherpa-ncnn-ffmpeg "portaudio")
-else()
-    target_link_libraries(sherpa-ncnn-ffmpeg "portaudio_static")
-endif()
+target_link_libraries(sherpa-ncnn-ffmpeg sherpa-ncnn-c-api)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(AVCODEC REQUIRED libavcodec)

--- a/ffmpeg-examples/Makefile
+++ b/ffmpeg-examples/Makefile
@@ -17,6 +17,11 @@ endif
 CFLAGS := $(shell pkg-config --cflags $(SHARED_LIBS)) -I.. -Wall -std=c++11 ${OPTFLAG}
 LDLIBS := $(shell pkg-config --libs $(SHARED_LIBS)) -L../build/lib -lsherpa-ncnn-c-api -lsherpa-ncnn-core -lkaldi-native-fbank-core -lncnn -lportaudio -lpthread -lm
 
+# If not macOS.
+ifneq ($(shell uname -s), Darwin)
+  CFLAGS += -fopenmp
+endif
+
 #Get libavutil version and extract major, minor and micro
 LIBAVUTIL_VERSION := $(shell pkg-config --modversion libavutil)
 LIBAVUTIL_MAJOR := $(shell echo "$(LIBAVUTIL_VERSION)" | awk -F. '{print $$1}')

--- a/ffmpeg-examples/Makefile
+++ b/ffmpeg-examples/Makefile
@@ -17,7 +17,7 @@ endif
 CFLAGS := $(shell pkg-config --cflags $(SHARED_LIBS)) -I.. -Wall -std=c++11 ${OPTFLAG}
 LDLIBS := $(shell pkg-config --libs $(SHARED_LIBS)) -L../build/lib -lsherpa-ncnn-c-api -lsherpa-ncnn-core -lkaldi-native-fbank-core -lncnn -lportaudio -lpthread -lm
 
-# If not macOS.
+# Set the flag if not macOS, or it fails with "DSO missing from command line".
 ifneq ($(shell uname -s), Darwin)
   CFLAGS += -fopenmp
 endif

--- a/ffmpeg-examples/Makefile
+++ b/ffmpeg-examples/Makefile
@@ -14,7 +14,7 @@ ifeq ($(GDB), TRUE)
 	OPTFLAG += -g
 endif
 
-CFLAGS := $(shell pkg-config --cflags $(SHARED_LIBS)) -I.. -Wall -std=c++11 -fopenmp ${OPTFLAG}
+CFLAGS := $(shell pkg-config --cflags $(SHARED_LIBS)) -I.. -Wall -std=c++11 ${OPTFLAG}
 LDLIBS := $(shell pkg-config --libs $(SHARED_LIBS)) -L../build/lib -lsherpa-ncnn-c-api -lsherpa-ncnn-core -lkaldi-native-fbank-core -lncnn -lportaudio -lpthread -lm
 
 #Get libavutil version and extract major, minor and micro
@@ -41,7 +41,7 @@ all: $(EXAMPLES)
 $(EXAMPLES): $(OBJS)
 	$(CC) $(addsuffix .o,$@) $(CFLAGS) $(LDLIBS) -o $@
 
-%.o : %.c
+%.o : %.cc
 	${CC} ${CFLAGS} -c -o $@ $<
 
 clean:

--- a/ffmpeg-examples/README.md
+++ b/ffmpeg-examples/README.md
@@ -1,3 +1,23 @@
+# ffmpeg-examples
+
+Enable sherpa-ncnn to use any url/file input that FFmpeg support.
+
+## Usage
+
+This examples is disabled by default, please enable it by:
+
+```bash
+cd sherpa-ncnn
+mkdir -p build
+cd build
+cmake -DSHERPA_NCNN_ENABLE_FFMPEG_EXAMPLES=ON ..
+make -j10
+```
+
+Please install ffmpeg first:
+
+* macOS: `brew install ffmpeg`
+
 # Fixes for errors
 
 To fix the following error:

--- a/ffmpeg-examples/README.md
+++ b/ffmpeg-examples/README.md
@@ -1,10 +1,10 @@
 # ffmpeg-examples
 
-Enable sherpa-ncnn to use any url/file input that FFmpeg support.
+Enable sherpa-ncnn to use any url/file input that FFmpeg supports.
 
 ## Usage
 
-This examples is disabled by default, please enable it by:
+This example is disabled by default, please enable it by:
 
 ```bash
 cd sherpa-ncnn

--- a/ffmpeg-examples/sherpa-ncnn-ffmpeg.cc
+++ b/ffmpeg-examples/sherpa-ncnn-ffmpeg.cc
@@ -55,14 +55,19 @@
  */
 
 #include <unistd.h>
+#ifdef __cplusplus
 extern "C" {
+#endif
+#include <libavutil/samplefmt.h>
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
 #include <libavutil/channel_layout.h>
 #include <libavutil/opt.h>
+#ifdef __cplusplus
 }
+#endif
 
 static const char *filter_descr = "aresample=16000,aformat=sample_fmts=s16:channel_layouts=mono";
 


### PR DESCRIPTION
By default, ffmpeg-examples is disabled, please enable it by:

cmake -DSHERPA_NCNN_ENABLE_FFMPEG_EXAMPLES=ON ..

You can also use make to build the ffmpeg-examples as before, however, cmake is better because the whole project is cmake, and you can debug in CLion, etc.