### PR TITLE
Support config by environment variables.

### DIFF
--- a/ffmpeg-examples/sherpa-ncnn-ffmpeg.cc
+++ b/ffmpeg-examples/sherpa-ncnn-ffmpeg.cc
@@ -305,8 +305,8 @@ static void Handler(int32_t sig) {
     }                                            \
   }
 
-int32_t ParseConfigFromENV(sherpa_ncnn::RecognizerConfig *config,
-                           std::string *input_url) {
+static int32_t ParseConfigFromENV(sherpa_ncnn::RecognizerConfig *config,
+                                  std::string *input_url) {
   int32_t parsed_required_envs = 0;
 
   sherpa_ncnn::ModelConfig &mc = config->model_config;
@@ -380,7 +380,7 @@ int32_t ParseConfigFromENV(sherpa_ncnn::RecognizerConfig *config,
   return parsed_required_envs;
 }
 
-void SetDefaultConfigurations(sherpa_ncnn::RecognizerConfig *config) {
+static void SetDefaultConfigurations(sherpa_ncnn::RecognizerConfig *config) {
   int32_t num_threads = 4;
   config->model_config.encoder_opt.num_threads = num_threads;
   config->model_config.decoder_opt.num_threads = num_threads;
@@ -396,9 +396,9 @@ void SetDefaultConfigurations(sherpa_ncnn::RecognizerConfig *config) {
   config->feat_config.feature_dim = 80;
 }
 
-int32_t OverwriteConfigByCLI(int32_t argc, char **argv,
-                             sherpa_ncnn::RecognizerConfig *config,
-                             std::string *input_url) {
+static int32_t OverwriteConfigByCLI(int32_t argc, char **argv,
+                                    sherpa_ncnn::RecognizerConfig *config,
+                                    std::string *input_url) {
   if (argc > 1) config->model_config.tokens = argv[1];
   if (argc > 2) config->model_config.encoder_param = argv[2];
   if (argc > 3) config->model_config.encoder_bin = argv[3];

--- a/ffmpeg-examples/sherpa-ncnn-ffmpeg.cc
+++ b/ffmpeg-examples/sherpa-ncnn-ffmpeg.cc
@@ -455,21 +455,21 @@ Usage:
     [num_threads] [decode_method, can be greedy_search/modified_beam_search]
 
 Or configure by environment variables:
-  env SHERPA_NCNN_TOKENS=/path/to/tokens.txt \
-    SHERPA_NCNN_ENCODER_PARAM=/path/to/encoder_jit_trace-pnnx.ncnn.param  \
-    SHERPA_NCNN_ENCODER_BIN=/path/to/encoder_jit_trace-pnnx.ncnn.bin \
-    SHERPA_NCNN_DECODER_PARAM=/path/to/decoder_jit_trace-pnnx.ncnn.param \
-    SHERPA_NCNN_DECODER_BIN=/path/to/decoder_jit_trace-pnnx.ncnn.bin \
-    SHERPA_NCNN_JOINER_PARAM=/path/to/joiner_jit_trace-pnnx.ncnn.param  \
-    SHERPA_NCNN_JOINER_BIN=/path/to/joiner_jit_trace-pnnx.ncnn.bin \
-    SHERPA_NCNN_INPUT_URL=ffmpeg-input-url \
-    SHERPA_NCNN_NUM_THREADS=4 \
-    SHERPA_NCNN_METHOD=greedy_search|modified_beam_search \
-    SHERPA_NCNN_ENABLE_ENDPOINT=on|off \
-    SHERPA_NCNN_RULE1_MIN_TRAILING_SILENCE=2.4 \
-    SHERPA_NCNN_RULE2_MIN_TRAILING_SILENCE=1.2 \
-    SHERPA_NCNN_RULE3_MIN_UTTERANCE_LENGTH=300 \
-    ./bin/sherpa-ncnn-ffmpeg
+  SHERPA_NCNN_TOKENS=/path/to/tokens.txt \
+  SHERPA_NCNN_ENCODER_PARAM=/path/to/encoder_jit_trace-pnnx.ncnn.param  \
+  SHERPA_NCNN_ENCODER_BIN=/path/to/encoder_jit_trace-pnnx.ncnn.bin \
+  SHERPA_NCNN_DECODER_PARAM=/path/to/decoder_jit_trace-pnnx.ncnn.param \
+  SHERPA_NCNN_DECODER_BIN=/path/to/decoder_jit_trace-pnnx.ncnn.bin \
+  SHERPA_NCNN_JOINER_PARAM=/path/to/joiner_jit_trace-pnnx.ncnn.param  \
+  SHERPA_NCNN_JOINER_BIN=/path/to/joiner_jit_trace-pnnx.ncnn.bin \
+  SHERPA_NCNN_INPUT_URL=ffmpeg-input-url \
+  SHERPA_NCNN_NUM_THREADS=4 \
+  SHERPA_NCNN_METHOD=greedy_search|modified_beam_search \
+  SHERPA_NCNN_ENABLE_ENDPOINT=on|off \
+  SHERPA_NCNN_RULE1_MIN_TRAILING_SILENCE=2.4 \
+  SHERPA_NCNN_RULE2_MIN_TRAILING_SILENCE=1.2 \
+  SHERPA_NCNN_RULE3_MIN_UTTERANCE_LENGTH=300 \
+  ./bin/sherpa-ncnn-ffmpeg
 
 Please refer to
 https://k2-fsa.github.io/sherpa/ncnn/pretrained_models/index.html

--- a/ffmpeg-examples/sherpa-ncnn-ffmpeg.cc
+++ b/ffmpeg-examples/sherpa-ncnn-ffmpeg.cc
@@ -83,11 +83,11 @@ static AVCodecContext *dec_ctx;
 AVFilterContext *buffersink_ctx;
 AVFilterContext *buffersrc_ctx;
 AVFilterGraph *filter_graph;
-static int audio_stream_index = -1;
+static int32_t audio_stream_index = -1;
 
-static int open_input_file(const char *filename) {
+static int32_t open_input_file(const char *filename) {
   const AVCodec *dec;
-  int ret;
+  int32_t ret;
 
   if ((ret = avformat_open_input(&fmt_ctx, filename, NULL, NULL)) < 0) {
     av_log(NULL, AV_LOG_ERROR, "Cannot open input file %s\n", filename);
@@ -123,16 +123,16 @@ static int open_input_file(const char *filename) {
   return 0;
 }
 
-static int init_filters(const char *filters_descr) {
+static int32_t init_filters(const char *filters_descr) {
   char args[512];
-  int ret = 0;
+  int32_t ret = 0;
   const AVFilter *abuffersrc = avfilter_get_by_name("abuffer");
   const AVFilter *abuffersink = avfilter_get_by_name("abuffersink");
   AVFilterInOut *outputs = avfilter_inout_alloc();
   AVFilterInOut *inputs = avfilter_inout_alloc();
   static const enum AVSampleFormat out_sample_fmts[] = {AV_SAMPLE_FMT_S16,
                                                         AV_SAMPLE_FMT_NONE};
-  static const int out_sample_rates[] = {16000, -1};
+  static const int32_t out_sample_rates[] = {16000, -1};
   const AVFilterLink *outlink;
   AVRational time_base = fmt_ctx->streams[audio_stream_index]->time_base;
 
@@ -247,7 +247,7 @@ static void sherpa_decode_frame(const AVFrame *frame,
                                 int32_t &segment_index) {
 #define N 3200  // 0.2 s. Sample rate is fixed to 16 kHz
   static float samples[N];
-  static int nb_samples = 0;
+  static int32_t nb_samples = 0;
   const int16_t *p = (int16_t *)frame->data[0];
 
   if (frame->nb_samples + nb_samples >= N) {
@@ -280,12 +280,12 @@ static void sherpa_decode_frame(const AVFrame *frame,
     nb_samples = 0;
   }
 
-  for (int i = 0; i < frame->nb_samples; i++) {
+  for (int32_t i = 0; i < frame->nb_samples; i++) {
     samples[nb_samples++] = p[i] / 32768.;
   }
 }
 
-static inline char *__av_err2str(int errnum) {
+static inline char *__av_err2str(int32_t errnum) {
   static char str[AV_ERROR_MAX_STRING_SIZE];
   memset(str, 0, sizeof(str));
   return av_make_error_string(str, AV_ERROR_MAX_STRING_SIZE, errnum);
@@ -306,9 +306,9 @@ static void Handler(int32_t sig) {
     }                                            \
   }
 
-int ParseConfigFromENV(sherpa_ncnn::RecognizerConfig *config,
+int32_t ParseConfigFromENV(sherpa_ncnn::RecognizerConfig *config,
                        std::string *input_url) {
-  int parsed_required_envs = 0;
+  int32_t parsed_required_envs = 0;
 
   sherpa_ncnn::ModelConfig &mc = config->model_config;
   SET_CONFIG_BY_ENV(mc.tokens, "SHERPA_NCNN_TOKENS", true);
@@ -397,7 +397,7 @@ void SetDefaultConfigurations(sherpa_ncnn::RecognizerConfig *config) {
   config->feat_config.feature_dim = 80;
 }
 
-int OverwriteConfigByCLI(int argc, char **argv,
+int32_t OverwriteConfigByCLI(int32_t argc, char **argv,
                          sherpa_ncnn::RecognizerConfig *config,
                          std::string *input_url) {
   if (argc > 1) config->model_config.tokens = argv[1];
@@ -409,7 +409,7 @@ int OverwriteConfigByCLI(int argc, char **argv,
   if (argc > 7) config->model_config.joiner_bin = argv[7];
   if (argc > 8) *input_url = argv[8];
   if (argc >= 10 && atoi(argv[9]) > 0) {
-    int num_threads = atoi(argv[9]);
+    int32_t num_threads = atoi(argv[9]);
     config->model_config.encoder_opt.num_threads = num_threads;
     config->model_config.decoder_opt.num_threads = num_threads;
     config->model_config.joiner_opt.num_threads = num_threads;
@@ -427,14 +427,14 @@ int OverwriteConfigByCLI(int argc, char **argv,
   return 0;
 }
 
-int main(int argc, char **argv) {
+int32_t main(int32_t argc, char **argv) {
   // Set the default values for config.
   sherpa_ncnn::RecognizerConfig config;
   SetDefaultConfigurations(&config);
 
   // Load and overwrite config from environment variables.
   std::string input_url;
-  int parsed_required_envs = ParseConfigFromENV(&config, &input_url);
+  int32_t parsed_required_envs = ParseConfigFromENV(&config, &input_url);
   if (parsed_required_envs < 0) {
     exit(-1);
   }
@@ -501,7 +501,7 @@ for a list of pre-trained models to download.
     exit(1);
   }
 
-  int ret;
+  int32_t ret;
   if ((ret = open_input_file(input_url.c_str())) < 0) {
     fprintf(stderr, "Open input file %s failed, r0=%d\n", input_url.c_str(),
             ret);

--- a/sherpa-ncnn/csrc/sherpa-ncnn-alsa.cc
+++ b/sherpa-ncnn/csrc/sherpa-ncnn-alsa.cc
@@ -103,8 +103,7 @@ as the device_name.
   sherpa_ncnn::DecoderConfig decoder_conf;
   if (argc == 11) {
     std::string method = argv[10];
-    if (method.compare("greedy_search") ||
-        method.compare("modified_beam_search")) {
+    if (method == "greedy_search" || method == "modified_beam_search") {
       decoder_conf.method = method;
     }
   }

--- a/sherpa-ncnn/csrc/sherpa-ncnn-microphone.cc
+++ b/sherpa-ncnn/csrc/sherpa-ncnn-microphone.cc
@@ -92,8 +92,7 @@ for a list of pre-trained models to download.
   const float expected_sampling_rate = 16000;
   if (argc == 10) {
     std::string method = argv[9];
-    if (method.compare("greedy_search") ||
-        method.compare("modified_beam_search")) {
+    if (method == "greedy_search" || method == "modified_beam_search") {
       config.decoder_config.method = method;
     }
   }

--- a/sherpa-ncnn/csrc/sherpa-ncnn.cc
+++ b/sherpa-ncnn/csrc/sherpa-ncnn.cc
@@ -68,8 +68,7 @@ for a list of pre-trained models to download.
   float expected_sampling_rate = 16000;
   if (argc == 11) {
     std::string method = argv[10];
-    if (method.compare("greedy_search") ||
-        method.compare("modified_beam_search")) {
+    if (method == "greedy_search" || method == "modified_beam_search") {
       config.decoder_config.method = method;
     }
   }


### PR DESCRIPTION
Sherpa supports config by CLI, for example:

```bash
./bin/sherpa-ncnn-ffmpeg  \
  ./models/tokens.txt \
  ./models/encoder_jit_trace-pnnx.ncnn.param  \
  ./models/encoder_jit_trace-pnnx.ncnn.bin \
  ./models/decoder_jit_trace-pnnx.ncnn.param \
  ./models/decoder_jit_trace-pnnx.ncnn.bin \
  ./models/joiner_jit_trace-pnnx.ncnn.param  \
  ./models/joiner_jit_trace-pnnx.ncnn.bin \
  rtmp://localhost/live/livestream
```

If start by docker, or k8s, it's better to config by envrionment variables, for example:

```bash
env SHERPA_NCNN_TOKENS=./models/tokens.txt \
  SHERPA_NCNN_ENCODER_PARAM=./models/encoder_jit_trace-pnnx.ncnn.param  \
  SHERPA_NCNN_ENCODER_BIN=./models/encoder_jit_trace-pnnx.ncnn.bin \
  SHERPA_NCNN_DECODER_PARAM=./models/decoder_jit_trace-pnnx.ncnn.param \
  SHERPA_NCNN_DECODER_BIN=./models/decoder_jit_trace-pnnx.ncnn.bin \
  SHERPA_NCNN_JOINER_PARAM=./models/joiner_jit_trace-pnnx.ncnn.param  \
  SHERPA_NCNN_JOINER_BIN=./models/joiner_jit_trace-pnnx.ncnn.bin \
  SHERPA_NCNN_INPUT_URL=rtmp://localhost/live/livestream \
./bin/sherpa-ncnn-ffmpeg
```

It makes it easier for user to change only some parameter, for example, set the `config.endpoint_config.rule2.min_trailing_silence` by setting:

```bash
SHERPA_NCNN_RULE2_MIN_TRAILING_SILENCE=0.8
```

Note that we will apply the configurations by:

1. Set some default configurations, for example, `num_threads = 4`
2. Load and reset the values by environement variables, such as `SHERPA_NCNN_NUM_THREADS=8`
3. Overwrite the configuration by CLI, for example `./bin/sherpa-ncnn-ffmpeg ... 6`