### PR TITLE
Support simple display, without window support.

### DIFF
--- a/sherpa-ncnn/csrc/display.h
+++ b/sherpa-ncnn/csrc/display.h
@@ -30,7 +30,7 @@ class Display {
   explicit Display(int32_t max_word_per_line = 60)
       : max_word_per_line_(max_word_per_line) {}
 
-  void Print(int32_t segment_id, const std::string &s) {
+  virtual void Print(int32_t segment_id, const std::string &s) {
 #ifdef _MSC_VER
     if (segment_id != -1) {
       if (last_segment_ != segment_id) {


### PR DESCRIPTION
The sherpa_ncnn::Display use a window and rewrite the current line, which might not work when another program read the stderr.

If the console width smaller than the sherpa_ncnn::Display window, it causes the text repeat, like this:

```text
3: in many languages this standard form came to be considered the
3: in many languages this standard form came to be considered the
3: in many languages this standard form came to be considered the
3: in many languages this standard form came to be considered the
3: in many languages this standard form came to be considered the
3: in many languages this standard form came to be considered the
3: in many languages this standard form came to be considered the
3: in many languages this standard form came to be considered the
  only proper one despite being derived from just one of many
  spoken varieties usually that of the people in power
```

This patch implements a simple display, without window support, doesn't rewrite current line. It only outputs the new text, which only works in greedy_search mode. It doesn't support modified_beam_search mode, which might change the generated text.

It writes text in a single line, so it's better for a program to read the text:

```text
1: descriptivism on the other hand gives us insight into how our minds work and the instinctive ways in which we structure our view of the world
2: ultimately grammar is best thought of as a set of linguistic habits that are constantly being negotiated and reinvented by the entire group of language users
```

Please enable the SimpleDisplay by environment variable `SHERPA_NCNN_SIMPLE_DISLAY`