### PR TITLE
Support ASD(Active speaker detection) for incorrect microphone.

### DIFF
--- a/ffmpeg-examples/CMakeLists.txt
+++ b/ffmpeg-examples/CMakeLists.txt
@@ -9,8 +9,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(AVCODEC REQUIRED libavcodec)
 include_directories(${AVCODEC_INCLUDE_DIRS})
 target_link_directories(sherpa-ncnn-ffmpeg PRIVATE ${AVCODEC_LIBRARY_DIRS})
-target_link_libraries(sherpa-ncnn-ffmpeg ${AVCODEC_LIBRARIES})
 # All libraries of FFmpeg shares the same include and library directory.
 # Note that ${AVCODEC_LIBRARIES} equals to avcodec, but we add it for consistence.
-target_link_libraries(sherpa-ncnn-ffmpeg avcodec avformat avfilter avutil swresample swscale avdevice)
+target_link_libraries(sherpa-ncnn-ffmpeg avformat avfilter avcodec avutil swresample swscale avdevice)
 


### PR DESCRIPTION
If user select incorrect microphone device, or muted it, FFmpeg get all zero samples, and K2 can't work. This PR detects and writes logs to warn user.

Write event logs to stdout to allow user to seperate it from ASR text which write to stderr.

Allow user to send SIGUSR1 about the stream republish event, so we will restart the ASD for new stream.

User can set the env SHERPA_NCNN_DISPLAY_LABEL for the ASR text prefix.