### PR TITLE
Support config ASD by env.

### DIFF
--- a/ffmpeg-examples/sherpa-ncnn-ffmpeg.cc
+++ b/ffmpeg-examples/sherpa-ncnn-ffmpeg.cc
@@ -329,7 +329,7 @@ static void Handler(int32_t sig) {
   }
 
 #define SET_INTEGER_BY_ENV(config, key)                  \
-  if (true) {                                            \
+  {                                                      \
     std::string val;                                     \
     SET_STRING_BY_ENV(val, "SHERPA_NCNN_ASD_ENDPOINTS"); \
     if (!val.empty() && ::atoi(val.c_str()) > 0) {       \


### PR DESCRIPTION
If there are SHERPA_NCNN_ASD_SAMPLES seconds of zero samples during SHERPA_NCNN_ASD_ENDPOINTS endpoints, it's no ASD and might be something wrong with microphone.

By default, disabled if SHERPA_NCNN_ASD_SAMPLES or SHERPA_NCNN_ASD_ENDPOINTS is zero.