### PR TITLE
Fix installing on windows about the python module

### DIFF
--- a/.github/workflows/test-pip-install.yaml
+++ b/.github/workflows/test-pip-install.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - nightly
+      - fix-windows-dll
   schedule:
     # minute (0-59)
     # hour (0-23)
@@ -56,7 +57,8 @@ jobs:
       - name: Install sherpa-ncnn
         shell: bash
         run: |
-          pip3 install --verbose -U sherpa-ncnn
+          # pip3 install --verbose -U sherpa-ncnn
+          python3 setup.py install
 
       - name: Run test
         shell: bash

--- a/.github/workflows/test-pip-install.yaml
+++ b/.github/workflows/test-pip-install.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - nightly
-      - fix-windows-dll
   schedule:
     # minute (0-59)
     # hour (0-23)
@@ -27,8 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:

--- a/.github/workflows/test-pip-install.yaml
+++ b/.github/workflows/test-pip-install.yaml
@@ -27,7 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:

--- a/.github/workflows/test-pip-install.yaml
+++ b/.github/workflows/test-pip-install.yaml
@@ -56,8 +56,7 @@ jobs:
       - name: Install sherpa-ncnn
         shell: bash
         run: |
-          # pip3 install --verbose -U sherpa-ncnn
-          python3 setup.py install
+          pip3 install --verbose -U sherpa-ncnn
 
       - name: Run test
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(sherpa-ncnn)
 
-set(SHERPA_NCNN_VERSION "1.7.0")
+set(SHERPA_NCNN_VERSION "1.8.0")
 
 # Disable warning about
 #

--- a/cmake/kaldi-native-fbank.cmake
+++ b/cmake/kaldi-native-fbank.cmake
@@ -46,7 +46,11 @@ function(download_kaldi_native_fbank)
   message(STATUS "kaldi-native-fbank's binary dir is ${kaldi_native_fbank_BINARY_DIR}")
 
   add_subdirectory(${kaldi_native_fbank_SOURCE_DIR} ${kaldi_native_fbank_BINARY_DIR})
-  install(TARGETS kaldi-native-fbank-core DESTINATION lib)
+  if(SHERPA_NCNN_ENABLE_PYTHON AND WIN32)
+    install(TARGETS kaldi-native-fbank-core DESTINATION ..)
+  else()
+    install(TARGETS kaldi-native-fbank-core DESTINATION lib)
+  endif()
 
   target_include_directories(kaldi-native-fbank-core
     INTERFACE

--- a/cmake/ncnn.cmake
+++ b/cmake/ncnn.cmake
@@ -173,7 +173,11 @@ function(download_ncnn)
   message(STATUS "ncnn's binary dir is ${ncnn_BINARY_DIR}")
 
   add_subdirectory(${ncnn_SOURCE_DIR} ${ncnn_BINARY_DIR})
-  install(TARGETS ncnn DESTINATION lib)
+  if(SHERPA_NCNN_ENABLE_PYTHON AND WIN32)
+    install(TARGETS ncnn DESTINATION ..)
+  else()
+    install(TARGETS ncnn DESTINATION lib)
+  endif()
 endfunction()
 
 download_ncnn()

--- a/sherpa-ncnn/csrc/CMakeLists.txt
+++ b/sherpa-ncnn/csrc/CMakeLists.txt
@@ -20,7 +20,12 @@ set(sherpa_ncnn_core_srcs
 )
 add_library(sherpa-ncnn-core ${sherpa_ncnn_core_srcs})
 target_link_libraries(sherpa-ncnn-core PUBLIC kaldi-native-fbank-core ncnn)
-install(TARGETS sherpa-ncnn-core DESTINATION lib)
+
+if(SHERPA_NCNN_ENABLE_PYTHON AND WIN32)
+  install(TARGETS sherpa-ncnn-core DESTINATION ..)
+else()
+  install(TARGETS sherpa-ncnn-core DESTINATION lib)
+endif()
 
 if(NOT SHERPA_NCNN_ENABLE_PYTHON)
   if(SHERPA_NCNN_ENABLE_BINARY)


### PR DESCRIPTION
People are getting the following error on windows when using `pip install sherpa-ncnn`.
```
Traceback (most recent call last):
  File ".github/scripts/test-recognizer.py", line 6, in <module>
    import sherpa_ncnn
  File "C:\hostedtoolcache\windows\Python\3.[8](https://github.com/k2-fsa/sherpa-ncnn/actions/runs/4505931882/jobs/7932189031#step:8:9).[10](https://github.com/k2-fsa/sherpa-ncnn/actions/runs/4505931882/jobs/7932189031#step:8:11)\x64\lib\site-packages\sherpa_ncnn\__init__.py", line 1, in <module>
    from .recognizer import Recognizer
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\sherpa_ncnn\recognizer.py", line 4, in <module>
    from _sherpa_ncnn import (
ImportError: DLL load failed while importing _sherpa_ncnn: The specified module could not be found.
```

The PR fixes that.