### PR TITLE
Added Timetamp

### DIFF
--- a/sherpa-ncnn/c-api/c-api.cc
+++ b/sherpa-ncnn/c-api/c-api.cc
@@ -124,22 +124,21 @@ SherpaNcnnResult *GetResult(SherpaNcnnRecognizer *p, SherpaNcnnStream *s) {
   std::copy(text.begin(), text.end(), const_cast<char *>(r->text));
   const_cast<char *>(r->text)[text.size()] = 0;
   r->count = res.tokens.size();
-  if( r->count > 0 ) {
-	// Each word ends with nullptr
-	r->tokens = new char[text.size() + r->count];
-	memset((void*)r->tokens, 0, text.size() + r->count );
-	r->timestamps = new float[r->count]; 
-	int pos = 0;
-	for( int i = 0; i < r->count; ++i ) {
-	  memcpy((void*)(r->tokens + pos), res.stokens[i].c_str(), res.stokens[i].size());
-	  pos += res.stokens[i].size() + 1;
-	  r->timestamps[i] = res.timestamps[i];
-	}
-  }
-  else 
-  {
-	r->timestamps = nullptr;
-	r->tokens = nullptr;
+  if (r->count > 0) {
+    // Each word ends with nullptr
+    r->tokens = new char[text.size() + r->count];
+    memset(reinterpret_cast<void*>(r->tokens), 0, text.size() + r->count);
+    r->timestamps = new float[r->count];
+    int pos = 0;
+    for (int i = 0; i < r->count; ++i) {
+      memcpy(reinterpret_cast<void*>(r->tokens + pos), res.stokens[i].c_str(),
+             res.stokens[i].size());
+      pos += res.stokens[i].size() + 1;
+      r->timestamps[i] = res.timestamps[i];
+    }
+  } else {
+    r->timestamps = nullptr;
+    r->tokens = nullptr;
   }
 
   return r;
@@ -147,10 +146,10 @@ SherpaNcnnResult *GetResult(SherpaNcnnRecognizer *p, SherpaNcnnStream *s) {
 
 void DestroyResult(const SherpaNcnnResult *r) {
   delete[] r->text;
-  if( r->timestamps != nullptr )
-	  delete[] r->timestamps;
-  if( r->tokens != nullptr )
-	  delete[] r->tokens;
+  if (r->timestamps != nullptr)
+      delete[] r->timestamps;
+  if (r->tokens != nullptr)
+      delete[] r->tokens;
   delete r;
 }
 

--- a/sherpa-ncnn/c-api/c-api.cc
+++ b/sherpa-ncnn/c-api/c-api.cc
@@ -127,11 +127,13 @@ SherpaNcnnResult *GetResult(SherpaNcnnRecognizer *p, SherpaNcnnStream *s) {
   if (r->count > 0) {
     // Each word ends with nullptr
     r->tokens = new char[text.size() + r->count];
-    memset(reinterpret_cast<void*>(r->tokens), 0, text.size() + r->count);
+    memset(reinterpret_cast<void*>(const_cast<char*>(r->tokens)), 0,
+             text.size() + r->count);
     r->timestamps = new float[r->count];
     int pos = 0;
-    for (int i = 0; i < r->count; ++i) {
-      memcpy(reinterpret_cast<void*>(r->tokens + pos), res.stokens[i].c_str(),
+    for (int32_t i = 0; i < r->count; ++i) {
+      memcpy(reinterpret_cast<void*>(const_cast<char*>(r->tokens + pos)),
+             res.stokens[i].c_str(),
              res.stokens[i].size());
       pos += res.stokens[i].size() + 1;
       r->timestamps[i] = res.timestamps[i];

--- a/sherpa-ncnn/c-api/c-api.cc
+++ b/sherpa-ncnn/c-api/c-api.cc
@@ -123,59 +123,25 @@ SherpaNcnnResult *GetResult(SherpaNcnnRecognizer *p, SherpaNcnnStream *s) {
   r->text = new char[text.size() + 1];
   std::copy(text.begin(), text.end(), const_cast<char *>(r->text));
   const_cast<char *>(r->text)[text.size()] = 0;
-  r->count = 0;
-  size_t count = res.tokens.size();
-  if( count > 0 )
+  r->count = res.tokens.size();
+  if( r->count > 0 )
   {
-	  // each word end with nullptr
-	  r->words = new char[text.size() + count];
-	  memset((void*)r->words, 0, text.size() + count );
-	  r->timestamps = new float[count]; // maximum number of timestamps
+	  // Each word ends with nullptr
+	  r->tokens = new char[text.size() + r->count];
+	  memset((void*)r->tokens, 0, text.size() + r->count );
+	  r->timestamps = new float[r->count]; 
 	  int pos = 0;
-	  std::string word = "";
-	  float start = 0;
-	  int index = 0;
-	  for( int i = 0; i < count; ++i )
+	  for( int i = 0; i < r->count; ++i )
 	  {
-		  if( res.words[i][0] == ' ' ) // if token is ' BLABLA', then last word is finished
-		  {
-			  if( word.size() > 0 )
-			  {
-				  memcpy((void*)(r->words + pos), word.c_str(), word.size());
-				  pos += word.size() + 1;
-				  r->timestamps[index++] = start;
-				  word = "";
-
-				  start = res.timestamps[i];
-				  word = res.words[i];
-			  }
-			  else // The first token is ' BLABLA'
-			  {
-				  start = res.timestamps[i];
-				  word = res.words[i];
-			  }
-		  }
-		  else
-		  {
-			  if( word.size() == 0 )
-			  {
-				  start = res.timestamps[i];
-			  }
-			  word += res.words[i];
-		  }
+		  memcpy((void*)(r->tokens + pos), res.stokens[i].c_str(), res.stokens[i].size());
+		  pos += res.stokens[i].size() + 1;
+		  r->timestamps[i] = res.timestamps[i];
 	  }
-	  if( word != "" )
-	  {
-		  memcpy((void*)(r->words + pos), word.c_str(), word.size());
-		  r->timestamps[index++] = start;
-	  }
-	  r->count = index;
-
   }
   else 
   {
 	r->timestamps = nullptr;
-	r->words = nullptr;
+	r->tokens = nullptr;
   }
 
   return r;
@@ -185,8 +151,8 @@ void DestroyResult(const SherpaNcnnResult *r) {
   delete[] r->text;
   if( r->timestamps != nullptr )
 	  delete[] r->timestamps;
-  if( r->words != nullptr )
-	  delete[] r->words;
+  if( r->tokens != nullptr )
+	  delete[] r->tokens;
   delete r;
 }
 

--- a/sherpa-ncnn/c-api/c-api.cc
+++ b/sherpa-ncnn/c-api/c-api.cc
@@ -124,19 +124,17 @@ SherpaNcnnResult *GetResult(SherpaNcnnRecognizer *p, SherpaNcnnStream *s) {
   std::copy(text.begin(), text.end(), const_cast<char *>(r->text));
   const_cast<char *>(r->text)[text.size()] = 0;
   r->count = res.tokens.size();
-  if( r->count > 0 )
-  {
-	  // Each word ends with nullptr
-	  r->tokens = new char[text.size() + r->count];
-	  memset((void*)r->tokens, 0, text.size() + r->count );
-	  r->timestamps = new float[r->count]; 
-	  int pos = 0;
-	  for( int i = 0; i < r->count; ++i )
-	  {
-		  memcpy((void*)(r->tokens + pos), res.stokens[i].c_str(), res.stokens[i].size());
-		  pos += res.stokens[i].size() + 1;
-		  r->timestamps[i] = res.timestamps[i];
-	  }
+  if( r->count > 0 ) {
+	// Each word ends with nullptr
+	r->tokens = new char[text.size() + r->count];
+	memset((void*)r->tokens, 0, text.size() + r->count );
+	r->timestamps = new float[r->count]; 
+	int pos = 0;
+	for( int i = 0; i < r->count; ++i ) {
+	  memcpy((void*)(r->tokens + pos), res.stokens[i].c_str(), res.stokens[i].size());
+	  pos += res.stokens[i].size() + 1;
+	  r->timestamps[i] = res.timestamps[i];
+	}
   }
   else 
   {

--- a/sherpa-ncnn/c-api/c-api.h
+++ b/sherpa-ncnn/c-api/c-api.h
@@ -114,7 +114,9 @@ typedef struct SherpaNcnnRecognizerConfig {
 
 typedef struct SherpaNcnnResult {
   const char *text;
-  // TODO: Add more fields
+  const char *words;
+  float* timestamps;
+  int count;
 } SherpaNcnnResult;
 
 typedef struct SherpaNcnnRecognizer SherpaNcnnRecognizer;

--- a/sherpa-ncnn/c-api/c-api.h
+++ b/sherpa-ncnn/c-api/c-api.h
@@ -114,7 +114,7 @@ typedef struct SherpaNcnnRecognizerConfig {
 
 typedef struct SherpaNcnnResult {
   const char *text;
-  const char *words;
+  const char *tokens;
   float* timestamps;
   int count;
 } SherpaNcnnResult;

--- a/sherpa-ncnn/c-api/c-api.h
+++ b/sherpa-ncnn/c-api/c-api.h
@@ -113,10 +113,19 @@ typedef struct SherpaNcnnRecognizerConfig {
 } SherpaNcnnRecognizerConfig;
 
 typedef struct SherpaNcnnResult {
+  // Recognized text
   const char *text;
+
+  // Pointer to continuous memory which holds string based tokens
+  // which are seperated by \0
   const char *tokens;
+
+  // Pointer to continuous memory which holds timestamps which
+  // are seperated by \0
   float* timestamps;
-  int count;
+
+  // The number of tokens/timestamps in above pointer
+  int32_t count;
 } SherpaNcnnResult;
 
 typedef struct SherpaNcnnRecognizer SherpaNcnnRecognizer;

--- a/sherpa-ncnn/csrc/decoder.h
+++ b/sherpa-ncnn/csrc/decoder.h
@@ -42,7 +42,7 @@ struct DecoderConfig {
 };
 
 struct DecoderResult {
-  /// Number of frames we have decoded so far
+  /// Number of frames we have decoded so far, counted after subsampling
   int32_t frame_offset = 0;
 
   /// The decoded token IDs so far

--- a/sherpa-ncnn/csrc/decoder.h
+++ b/sherpa-ncnn/csrc/decoder.h
@@ -42,6 +42,9 @@ struct DecoderConfig {
 };
 
 struct DecoderResult {
+  /// Number of frames we have decoded so far
+  int32_t frame_offset = 0;
+
   /// The decoded token IDs so far
   std::vector<int32_t> tokens;
 

--- a/sherpa-ncnn/csrc/greedy-search-decoder.cc
+++ b/sherpa-ncnn/csrc/greedy-search-decoder.cc
@@ -59,6 +59,7 @@ void GreedySearchDecoder::Decode(ncnn::Mat encoder_out, DecoderResult *result) {
     decoder_out = model_->RunDecoder(decoder_input);
   }
 
+  int32_t frame_offset = result->frame_offset;
   for (int32_t t = 0; t != encoder_out.h; ++t) {
     ncnn::Mat encoder_out_t(encoder_out.w, encoder_out.row(t));
     ncnn::Mat joiner_out = model_->RunJoiner(encoder_out_t, decoder_out);
@@ -75,11 +76,13 @@ void GreedySearchDecoder::Decode(ncnn::Mat encoder_out, DecoderResult *result) {
       ncnn::Mat decoder_input = BuildDecoderInput(*result);
       decoder_out = model_->RunDecoder(decoder_input);
       result->num_trailing_blanks = 0;
+      result->timestamps.push_back(t + frame_offset);
     } else {
       ++result->num_trailing_blanks;
     }
   }
 
+  result->frame_offset += encoder_out.h;
   result->decoder_out = decoder_out;
 }
 

--- a/sherpa-ncnn/csrc/modified-beam-search-decoder.cc
+++ b/sherpa-ncnn/csrc/modified-beam-search-decoder.cc
@@ -169,6 +169,7 @@ void ModifiedBeamSearchDecoder::Decode(ncnn::Mat encoder_out,
     auto topk = TopkIndex(static_cast<float *>(joiner_out),
                           joiner_out.w * joiner_out.h, num_active_paths_);
 
+	int32_t frame_offset = result->frame_offset;
     for (auto i : topk) {
       int32_t hyp_index = i / joiner_out.w;
       int32_t new_token = i % joiner_out.w;
@@ -181,6 +182,7 @@ void ModifiedBeamSearchDecoder::Decode(ncnn::Mat encoder_out,
       if (new_token != 0) {
         new_hyp.ys.push_back(new_token);
         new_hyp.num_trailing_blanks = 0;
+		new_hyp.timestamps.push_back(t + frame_offset);
       } else {
         ++new_hyp.num_trailing_blanks;
       }
@@ -190,6 +192,7 @@ void ModifiedBeamSearchDecoder::Decode(ncnn::Mat encoder_out,
   }
 
   result->hyps = std::move(cur);
+  result->frame_offset += encoder_out.h;
   auto hyp = result->hyps.GetMostProbable(true);
 
   // set decoder_out in case of endpointing

--- a/sherpa-ncnn/csrc/modified-beam-search-decoder.cc
+++ b/sherpa-ncnn/csrc/modified-beam-search-decoder.cc
@@ -169,7 +169,7 @@ void ModifiedBeamSearchDecoder::Decode(ncnn::Mat encoder_out,
     auto topk = TopkIndex(static_cast<float *>(joiner_out),
                           joiner_out.w * joiner_out.h, num_active_paths_);
 
-	int32_t frame_offset = result->frame_offset;
+    int32_t frame_offset = result->frame_offset;
     for (auto i : topk) {
       int32_t hyp_index = i / joiner_out.w;
       int32_t new_token = i % joiner_out.w;
@@ -182,7 +182,7 @@ void ModifiedBeamSearchDecoder::Decode(ncnn::Mat encoder_out,
       if (new_token != 0) {
         new_hyp.ys.push_back(new_token);
         new_hyp.num_trailing_blanks = 0;
-		new_hyp.timestamps.push_back(t + frame_offset);
+        new_hyp.timestamps.push_back(t + frame_offset);
       } else {
         ++new_hyp.num_trailing_blanks;
       }

--- a/sherpa-ncnn/csrc/recognizer.cc
+++ b/sherpa-ncnn/csrc/recognizer.cc
@@ -176,7 +176,7 @@ class Recognizer::Impl {
     DecoderResult decoder_result = s->GetResult();
     decoder_->StripLeadingBlanks(&decoder_result);
 
-    // Those 2 parameter figured out from sherpa source code
+    // Those 2 parameters are figured out from sherpa source code
     int32_t frame_shift_ms = 10;
     int32_t subsampling_factor = 4;
     return Convert(decoder_result, sym_, frame_shift_ms, subsampling_factor);

--- a/sherpa-ncnn/csrc/recognizer.cc
+++ b/sherpa-ncnn/csrc/recognizer.cc
@@ -38,14 +38,14 @@ static RecognitionResult Convert(const DecoderResult &src,
 								 int32_t subsampling_factor) {
   RecognitionResult ans;
   ans.tokens.reserve(src.tokens.size());
-  ans.words.reserve(src.tokens.size());
+  ans.stokens.reserve(src.tokens.size());
   ans.timestamps.reserve(src.timestamps.size());
 
   std::string text;
   for (auto i : src.tokens) {
     auto sym = sym_table[i];
     text.append(sym);
-	ans.words.push_back(sym);
+	ans.stokens.push_back(sym);
     ans.tokens.push_back(i);
   }
 

--- a/sherpa-ncnn/csrc/recognizer.cc
+++ b/sherpa-ncnn/csrc/recognizer.cc
@@ -37,7 +37,6 @@ static RecognitionResult Convert(const DecoderResult &src,
 								 int32_t frame_shift_ms,
 								 int32_t subsampling_factor) {
   RecognitionResult ans;
-  ans.tokens.reserve(src.tokens.size());
   ans.stokens.reserve(src.tokens.size());
   ans.timestamps.reserve(src.timestamps.size());
 
@@ -46,19 +45,15 @@ static RecognitionResult Convert(const DecoderResult &src,
     auto sym = sym_table[i];
     text.append(sym);
 	ans.stokens.push_back(sym);
-    ans.tokens.push_back(i);
   }
 
   ans.text = std::move(text);
   ans.tokens = src.tokens;
   float frame_shift_s = frame_shift_ms / 1000. * subsampling_factor;
-  //std::cout<<"frame_shift="<<frame_shift_s;
   for (auto t : src.timestamps) {
     float time = frame_shift_s * t;
-	//std::cout<<",["<<t<<"|"<<time<<"]";
     ans.timestamps.push_back(time);
   }
-  //std::cout<<std::endl;
   return ans;
 }
 

--- a/sherpa-ncnn/csrc/recognizer.cc
+++ b/sherpa-ncnn/csrc/recognizer.cc
@@ -28,14 +28,12 @@
 #include "sherpa-ncnn/csrc/greedy-search-decoder.h"
 #include "sherpa-ncnn/csrc/modified-beam-search-decoder.h"
 
-#include <iostream>
-
 namespace sherpa_ncnn {
 
 static RecognitionResult Convert(const DecoderResult &src,
                                  const SymbolTable &sym_table,
-								 int32_t frame_shift_ms,
-								 int32_t subsampling_factor) {
+                                 int32_t frame_shift_ms,
+                                 int32_t subsampling_factor) {
   RecognitionResult ans;
   ans.stokens.reserve(src.tokens.size());
   ans.timestamps.reserve(src.timestamps.size());
@@ -44,7 +42,7 @@ static RecognitionResult Convert(const DecoderResult &src,
   for (auto i : src.tokens) {
     auto sym = sym_table[i];
     text.append(sym);
-	ans.stokens.push_back(sym);
+    ans.stokens.push_back(sym);
   }
 
   ans.text = std::move(text);
@@ -178,13 +176,10 @@ class Recognizer::Impl {
     DecoderResult decoder_result = s->GetResult();
     decoder_->StripLeadingBlanks(&decoder_result);
 
-    //return Convert(decoder_result, sym_);
-	// Those 2 parameter figured out from sherpa source code
-	int32_t frame_shift_ms = 10;
-	int32_t subsampling_factor = 4;
+    // Those 2 parameter figured out from sherpa source code
+    int32_t frame_shift_ms = 10;
+    int32_t subsampling_factor = 4;
     return Convert(decoder_result, sym_, frame_shift_ms, subsampling_factor);
-			//config_.feat_config.fbank_opts.frame_opts.frame_shift_ms,
-			//model_->SubsamplingFactor());
   }
 
  private:

--- a/sherpa-ncnn/csrc/recognizer.h
+++ b/sherpa-ncnn/csrc/recognizer.h
@@ -37,6 +37,8 @@ struct RecognitionResult {
   std::string text;
   std::vector<float> timestamps;
   std::vector<int32_t> tokens;
+
+  // String based tokens
   std::vector<std::string> stokens;
 
   std::string ToString() const;

--- a/sherpa-ncnn/csrc/recognizer.h
+++ b/sherpa-ncnn/csrc/recognizer.h
@@ -37,7 +37,7 @@ struct RecognitionResult {
   std::string text;
   std::vector<float> timestamps;
   std::vector<int32_t> tokens;
-  std::vector<std::string> words;
+  std::vector<std::string> stokens;
 
   std::string ToString() const;
 };

--- a/sherpa-ncnn/csrc/recognizer.h
+++ b/sherpa-ncnn/csrc/recognizer.h
@@ -34,9 +34,10 @@
 namespace sherpa_ncnn {
 
 struct RecognitionResult {
-  std::vector<int32_t> tokens;
   std::string text;
   std::vector<float> timestamps;
+  std::vector<int32_t> tokens;
+  std::vector<std::string> words;
 
   std::string ToString() const;
 };

--- a/sherpa-ncnn/csrc/stream.cc
+++ b/sherpa-ncnn/csrc/stream.cc
@@ -50,7 +50,11 @@ class Stream::Impl {
 
   int32_t &GetNumProcessedFrames() { return num_processed_frames_; }
 
-  void SetResult(const DecoderResult &r) { result_ = r; }
+  void SetResult(const DecoderResult &r) { 
+	  int32_t offset = result_.frame_offset;
+	  result_ = r; 
+	  result_.frame_offset = offset;
+  }
 
   DecoderResult &GetResult() { return result_; }
 


### PR DESCRIPTION
Added timestamp for greed search and modified beam search decoder. 

SherpaNcnnResult now includes tokens, timestamps and count besides of existing text field.  Tokens and timestamps are stored in continuous memory in which each token and timestamp ends with nullptr. Use count and pointer increment to get each token and timestamp.

Client can compose words from tokens. For English, the first token of  new word starts with space, while for Chinese, each token is a word. 