### PR TITLE
Fix encoding issues for C#

### DIFF
--- a/.github/workflows/dot-net.yaml
+++ b/.github/workflows/dot-net.yaml
@@ -104,10 +104,10 @@ jobs:
         with:
           dotnet-version: 3.1.x
 
-      - name: Setup .NET 6.0
+      - name: Setup .NET 7.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
 
       - name: Check dotnet
         run: dotnet --info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(sherpa-ncnn)
 
-set(SHERPA_NCNN_VERSION "1.9.0")
+set(SHERPA_NCNN_VERSION "1.9.1")
 
 # Disable warning about
 #

--- a/scripts/dotnet/sherpa-ncnn.cs
+++ b/scripts/dotnet/sherpa-ncnn.cs
@@ -111,25 +111,25 @@ public class OnlineRecognizer : IDisposable {
   private const string dllName = "sherpa-ncnn-c-api";
 
   [DllImport(dllName, EntryPoint="CreateRecognizer")]
-  public static extern IntPtr CreateOnlineRecognizer(ref OnlineRecognizerConfig config);
+  private static extern IntPtr CreateOnlineRecognizer(ref OnlineRecognizerConfig config);
 
   [DllImport(dllName, EntryPoint="DestroyRecognizer")]
-  public static extern void DestroyOnlineRecognizer(IntPtr handle);
+  private static extern void DestroyOnlineRecognizer(IntPtr handle);
 
   [DllImport(dllName, EntryPoint="CreateStream")]
-  public static extern IntPtr CreateOnlineStream(IntPtr handle);
+  private static extern IntPtr CreateOnlineStream(IntPtr handle);
 
   [DllImport(dllName)]
-  public static extern int IsReady(IntPtr handle, IntPtr stream);
+  private static extern int IsReady(IntPtr handle, IntPtr stream);
 
   [DllImport(dllName, EntryPoint="Decode")]
-  public static extern void Decode(IntPtr handle, IntPtr stream);
+  private static extern void Decode(IntPtr handle, IntPtr stream);
 
   [DllImport(dllName)]
-  public static extern IntPtr GetResult(IntPtr handle, IntPtr stream);
+  private static extern IntPtr GetResult(IntPtr handle, IntPtr stream);
 
   [DllImport(dllName)]
-  public static extern void DestroyResult(IntPtr result);
+  private static extern void DestroyResult(IntPtr result);
 }
 
 
@@ -169,19 +169,19 @@ public class OnlineStream : IDisposable {
   private const string dllName = "sherpa-ncnn-c-api";
 
   [DllImport(dllName, EntryPoint="DestroyStream")]
-  public static extern void DestroyOnlineStream(IntPtr handle);
+  private static extern void DestroyOnlineStream(IntPtr handle);
 
   [DllImport(dllName)]
-  public static extern void AcceptWaveform(IntPtr handle, float sampleRate, float[] samples, int n);
+  private static extern void AcceptWaveform(IntPtr handle, float sampleRate, float[] samples, int n);
 
   [DllImport(dllName)]
-  public static extern void InputFinished(IntPtr handle);
+  private static extern void InputFinished(IntPtr handle);
 }
 
 public class OnlineRecognizerResult {
   public OnlineRecognizerResult(IntPtr handle) {
     Impl impl = (Impl)Marshal.PtrToStructure(handle, typeof(Impl));
-    _text = Marshal.PtrToStringAnsi(impl.Text);
+    _text = Marshal.PtrToStringUTF8(impl.Text);
   }
 
   [StructLayout(LayoutKind.Sequential)]

--- a/scripts/dotnet/sherpa-ncnn.csproj.in
+++ b/scripts/dotnet/sherpa-ncnn.csproj.in
@@ -4,7 +4,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <OutputType>Library</OutputType>
     <LangVersion>8.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <RuntimeIdentifiers>linux-x64;osx-x64;win-x64</RuntimeIdentifiers>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>sherpa-ncnn</AssemblyName>

--- a/scripts/dotnet/sherpa-ncnn.csproj.runtime.in
+++ b/scripts/dotnet/sherpa-ncnn.csproj.runtime.in
@@ -3,7 +3,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <RuntimeIdentifier>{{ dotnet_rid }}</RuntimeIdentifier>
     <AssemblyName>sherpa-ncnn</AssemblyName>
     <Version>{{ version }}</Version>


### PR DESCRIPTION
Change Marshal.PtrToStringAnsi to Marshal.PtrToStringUTF8 to fix encoding issues on Windows.

Since PtrToStringUTF8 is only available from .netstandard2.1, we upgrade .netstandard2.0 to .netstandard2.1