### PR TITLE
Release v2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(sherpa-ncnn)
 
-set(SHERPA_NCNN_VERSION "1.9.1")
+set(SHERPA_NCNN_VERSION "2.0")
 
 # Disable warning about
 #

--- a/pack-for-embedded-systems.sh
+++ b/pack-for-embedded-systems.sh
@@ -29,8 +29,8 @@ wget \
   https://github.com/csukuangfj/kaldi-native-fbank/archive/refs/tags/v1.14.tar.gz
 
 wget \
-  -O ncnn-sherpa-0.9.tar.gz \
-  https://github.com/csukuangfj/ncnn/archive/refs/tags/sherpa-0.9.tar.gz
+  -O ncnn-sherpa-1.0.tar.gz \
+  https://github.com/csukuangfj/ncnn/archive/refs/tags/sherpa-1.0.tar.gz
 
 cat >README.md <<EOF
 Please put files from this folder to the directory \$HOME/asr/
@@ -48,7 +48,7 @@ It should print something like below:
 ls -lh \$HOME/asr
 total 24368
 -rw-r--r--   1 fangjun  staff    59K Feb  2 17:01 kaldi-native-fbank-1.14.tar.gz
--rw-r--r--   1 fangjun  staff    12M Feb  2 17:01 sherpa-0.9.tar.gz
+-rw-r--r--   1 fangjun  staff    12M Feb  2 17:01 sherpa-1.0.tar.gz
 drwxr-xr-x  29 fangjun  staff   928B Feb  2 16:05 sherpa-ncnn-${SHERPA_NCNN_VERSION}
 
 # Note: It is OK if the versions of the above files are different.


### PR DESCRIPTION
- Use the master branch from tencent/ncnn
- enable GPU support for zipformer
- enable fp16 support for LSTM and zipformer
- You need to re-export zipformer models to sherpa-ncnn or re-download zipformer models

We have pre-built APKs at
https://huggingface.co/csukuangfj/sherpa-ncnn-apk/tree/main

![Screenshot 2023-05-19 at 22 03 17](https://github.com/k2-fsa/sherpa-ncnn/assets/5284924/51a3a7c3-9bac-4146-9f64-f0013dae443f)
 