### PR TITLE
fix garbled console output with chinese characters

### DIFF
--- a/python-api-examples/speech-recognition-from-microphone-with-endpoint-detection.py
+++ b/python-api-examples/speech-recognition-from-microphone-with-endpoint-detection.py
@@ -52,7 +52,6 @@ def main():
     last_result = ""
     segment_id = 0
 
-    display = sherpa_ncnn.Display(max_word_per_line=30)
 
     with sd.InputStream(channels=1, dtype="float32", samplerate=sample_rate) as s:
         while True:
@@ -65,10 +64,11 @@ def main():
             result = recognizer.text
             if result and (last_result != result):
                 last_result = result
-                display.print(segment_id, result)
+                print("\r{}:{}".format(segment_id, result), end="", flush=True)
 
             if is_endpoint:
                 if result:
+                    print("\r{}:{}".format(segment_id, result), flush=True)
                     segment_id += 1
                 recognizer.reset()
 

--- a/python-api-examples/speech-recognition-from-microphone.py
+++ b/python-api-examples/speech-recognition-from-microphone.py
@@ -44,7 +44,6 @@ def main():
     sample_rate = recognizer.sample_rate
     samples_per_read = int(0.1 * sample_rate)  # 0.1 second = 100 ms
     last_result = ""
-    display = sherpa_ncnn.Display()
     with sd.InputStream(channels=1, dtype="float32", samplerate=sample_rate) as s:
         while True:
             samples, _ = s.read(samples_per_read)  # a blocking read
@@ -53,7 +52,7 @@ def main():
             result = recognizer.text
             if last_result != result:
                 last_result = result
-                display.print(-1, result)
+                print("\r{}".format(result), end="", flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
chinese characters can normal show in console, some (not all) window systems, sherpa_ncnn.Display() cannot handle the encoding correctly, while python's print works fine. 