### PR TITLE
Implemented tokens, stokens, and timestamps in Python API

### DIFF
--- a/sherpa-ncnn/python/csrc/recognizer.cc
+++ b/sherpa-ncnn/python/csrc/recognizer.cc
@@ -49,7 +49,7 @@ static void PybindRecognitionResult(py::module *m) {
       .def_property_readonly(
           "tokens", [](PyClass &self) -> std::vector<int> { return self.tokens; })
       .def_property_readonly(
-          "stokens", [](PyClass &self) -> std::vector<std::__cxx11::basic_string<char>> { return self.stokens; })
+          "stokens", [](PyClass &self) -> std::vector<std::string> { return self.stokens; })
       .def_property_readonly(
           "timestamps", [](PyClass &self) -> std::vector<float> { return self.timestamps; });
 }

--- a/sherpa-ncnn/python/csrc/recognizer.cc
+++ b/sherpa-ncnn/python/csrc/recognizer.cc
@@ -45,7 +45,13 @@ static void PybindRecognitionResult(py::module *m) {
   using PyClass = RecognitionResult;
   py::class_<PyClass>(*m, "RecognitionResult")
       .def_property_readonly(
-          "text", [](PyClass &self) -> std::string { return self.text; });
+          "text", [](PyClass &self) -> std::string { return self.text; })
+      .def_property_readonly(
+          "tokens", [](PyClass &self) -> std::vector<int> { return self.tokens; })
+      .def_property_readonly(
+          "stokens", [](PyClass &self) -> std::vector<std::__cxx11::basic_string<char>> { return self.stokens; })
+      .def_property_readonly(
+          "timestamps", [](PyClass &self) -> std::vector<float> { return self.timestamps; });
 }
 
 static void PybindRecognizerConfig(py::module *m) {

--- a/sherpa-ncnn/python/sherpa_ncnn/recognizer.py
+++ b/sherpa-ncnn/python/sherpa_ncnn/recognizer.py
@@ -226,6 +226,18 @@ class Recognizer(object):
         return self.recognizer.get_result(self.stream).text
 
     @property
+    def tokens(self):
+        return self.recognizer.get_result(self.stream).tokens
+
+    @property
+    def stokens(self):
+        return self.recognizer.get_result(self.stream).stokens
+
+    @property
+    def timestamps(self):
+        return self.recognizer.get_result(self.stream).timestamps
+
+    @property
     def is_endpoint(self):
         return self.recognizer.is_endpoint(self.stream)
 


### PR DESCRIPTION
Implemented `tokens`, `stokens`, and `timestamps` in Python API. I've tested this on Linux and MacOS and it seems to work.