### PR TITLE
build script for android-x86

### DIFF
--- a/build-android-x86.sh
+++ b/build-android-x86.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -ex
+
+# see https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-android
+
+dir=build-android-x86
+
+mkdir -p $dir
+cd $dir
+
+# Note from https://github.com/Tencent/ncnn/wiki/how-to-build#build-for-android
+# (optional) remove the hardcoded debug flag in Android NDK android-ndk
+# issue: https://github.com/android/ndk/issues/243
+#
+# open $ANDROID_NDK/build/cmake/android.toolchain.cmake for ndk < r23
+# or $ANDROID_NDK/build/cmake/android-legacy.toolchain.cmake for ndk >= r23
+#
+# delete "-g" line
+#
+# list(APPEND ANDROID_COMPILER_FLAGS
+#   -g
+#   -DANDROID
+
+if [ -z $ANDROID_NDK ]; then
+  ANDROID_NDK=/ceph-fj/fangjun/software/android-sdk/ndk/21.0.6113669
+  # or use
+  # ANDROID_NDK=/ceph-fj/fangjun/software/android-ndk
+  #
+  # Inside the $ANDROID_NDK directory, you can find a binary ndk-build
+  # and some other files like the file "build/cmake/android.toolchain.cmake"
+
+  if [ ! -d $ANDROID_NDK ]; then
+    # For macOS, I have installed Android Studio, select the menu
+    # Tools -> SDK manager -> Android SDK
+    # and set "Android SDK location" to /Users/fangjun/software/my-android
+    ANDROID_NDK=/Users/fangjun/software/my-android/ndk/22.1.7171670
+  fi
+fi
+
+if [ ! -d $ANDROID_NDK ]; then
+  echo Please set the environment variable ANDROID_NDK before you run this script
+  exit 1
+fi
+
+echo "ANDROID_NDK: $ANDROID_NDK"
+sleep 1
+
+cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DSHERPA_NCNN_ENABLE_PORTAUDIO=OFF \
+    -DSHERPA_NCNN_ENABLE_BINARY=OFF \
+    -DSHERPA_NCNN_ENABLE_TEST=OFF \
+    -DSHERPA_NCNN_ENABLE_C_API=OFF \
+    -DSHERPA_NCNN_ENABLE_GENERATE_INT8_SCALE_TABLE=OFF \
+    -DCMAKE_INSTALL_PREFIX=./install \
+    -DANDROID_ABI="x86" \
+    -DANDROID_PLATFORM=android-14 ..
+make VERBOSE=1 -j4
+make install/strip

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -20,11 +20,12 @@ log "Building APK for sherpa-ncnn v${SHERPA_NCNN_VERSION}"
 
 log "====================arm64-v8a================="
 ./build-android-arm64-v8a.sh
-log "====================x86-64===================="
-./build-android-armv7-eabi.sh
 log "====================armv7-eabi================"
+./build-android-armv7-eabi.sh
+log "====================x86-64===================="
 ./build-android-x86-64.sh
-log "----------------------------------------------"
+log "====================x86===================="
+./build-android-x86.sh
 
 
 # Download the model
@@ -50,7 +51,7 @@ tree ./android/SherpaNcnn/app/src/main/assets/
 
 mkdir -p apks
 
-for arch in arm64-v8a armeabi-v7a x86_64; do
+for arch in arm64-v8a armeabi-v7a x86_64 x86; do
   log "------------------------------------------------------------"
   log "build apk for $arch"
   log "------------------------------------------------------------"


### PR DESCRIPTION
Fixes #227 

The generated libs should be copied to
```
android/SherpaNcnn/app/src/main/jniLibs/x86/
```