### PR TITLE
[Not for merge] Support 32-bit samples

### DIFF
--- a/sherpa-ncnn/csrc/alsa.cc
+++ b/sherpa-ncnn/csrc/alsa.cc
@@ -26,13 +26,13 @@
 
 namespace sherpa_ncnn {
 
-void ToFloat(const std::vector<int16_t> &in, int32_t num_channels,
+void ToFloat(const std::vector<int32_t> &in, int32_t num_channels,
              std::vector<float> *out) {
   out->resize(in.size() / num_channels);
 
   int32_t n = in.size();
   for (int32_t i = 0, k = 0; i < n; i += num_channels, ++k) {
-    (*out)[k] = in[i] / 32768.;
+    (*out)[k] = in[i] / float(1 << 31);
   }
 }
 
@@ -80,7 +80,7 @@ and if you want to select card 3 and the device 0 on that card, please use:
   }
 
   err = snd_pcm_hw_params_set_format(capture_handle_, hw_params,
-                                     SND_PCM_FORMAT_S16_LE);
+                                     SND_PCM_FORMAT_S32_LE);
   if (err) {
     fprintf(stderr, "Failed to set format: %s\n", snd_strerror(err));
     exit(-1);

--- a/sherpa-ncnn/csrc/alsa.h
+++ b/sherpa-ncnn/csrc/alsa.h
@@ -50,7 +50,7 @@ class Alsa {
   int32_t actual_channel_count_ = 1;
 
   std::unique_ptr<LinearResample> resampler_;
-  std::vector<int16_t> samples_;  // directly from the microphone
+  std::vector<int32_t> samples_;  // directly from the microphone
   std::vector<float> samples1_;   // normalized version of samples_
   std::vector<float> samples2_;   // possibly resampled from samples1_
 };


### PR DESCRIPTION
Some microphones support only 32-bit samples. This pull-request shows how to change the code to support 32-bit samples.