### PR TITLE
fix build warning and error with gcc-13

### DIFF
--- a/sherpa-ncnn/csrc/symbol-table.cc
+++ b/sherpa-ncnn/csrc/symbol-table.cc
@@ -19,9 +19,9 @@
 #include "sherpa-ncnn/csrc/symbol-table.h"
 
 #include <cassert>
+#include <cstdint>
 #include <fstream>
 #include <sstream>
-#include <strstream>
 
 #if __ANDROID_API__ >= 9
 #include "android/asset_manager.h"


### PR DESCRIPTION
```
In file included from /usr/include/c++/13/backward/strstream:50,
                 from /home/nihui/osd/sherpa-ncnn/sherpa-ncnn/csrc/symbol-table.cc:24:
/usr/include/c++/13/backward/backward_warning.h:32:2: 警告：#warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
   32 | #warning \
      |  ^~~~~~~
/home/nihui/osd/sherpa-ncnn/sherpa-ncnn/csrc/symbol-table.cc: In member function ‘void sherpa_ncnn::SymbolTable::Init(std::istream&)’:
/home/nihui/osd/sherpa-ncnn/sherpa-ncnn/csrc/symbol-table.cc:63:13: 错误：‘uint8_t’不是一个类型名   63 |       const uint8_t *p = reinterpret_cast<const uint8_t *>(sym.c_str());
      |             ^~~~~~~
/home/nihui/osd/sherpa-ncnn/sherpa-ncnn/csrc/symbol-table.cc:25:1: 附注：‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   24 | #include <strstream>
  +++ |+#include <cstdint>
   25 | 
/home/nihui/osd/sherpa-ncnn/sherpa-ncnn/csrc/symbol-table.cc:64:11: 错误：‘p’在此作用域中尚未声明   64 |       if (p[0] == 0xe2 && p[1] == 0x96 && p[2] == 0x81) {
      |           ^
```