### PR TITLE
fix build error with ndk

### DIFF
--- a/sherpa-ncnn/csrc/symbol-table.cc
+++ b/sherpa-ncnn/csrc/symbol-table.cc
@@ -23,10 +23,12 @@
 #include <fstream>
 #include <sstream>
 
+
 #if __ANDROID_API__ >= 9
 #include "android/asset_manager.h"
 #include "android/asset_manager_jni.h"
 #include "android/log.h"
+#include <strstream>
 #endif
 
 namespace sherpa_ncnn {


### PR DESCRIPTION
```
/Users/finger/Projects/ClionProjects/sherpa-ncnn/sherpa-ncnn/csrc/symbol-table.cc:50:18: error: expected ';' after expression
  std::istrstream is(p, asset_length);
                 ^
                 ;
/Users/finger/Projects/ClionProjects/sherpa-ncnn/sherpa-ncnn/csrc/symbol-table.cc:50:8: error: no member named 'istrstream' in namespace 'std'
  std::istrstream is(p, asset_length);
  ~~~~~^
/Users/finger/Projects/ClionProjects/sherpa-ncnn/sherpa-ncnn/csrc/symbol-table.cc:50:19: error: use of undeclared identifier 'is'
  std::istrstream is(p, asset_length);
                  ^
/Users/finger/Projects/ClionProjects/sherpa-ncnn/sherpa-ncnn/csrc/symbol-table.cc:51:8: error: use of undeclared identifier 'is'
  Init(is);
       ^
4 errors generated.
make[2]: *** [sherpa-ncnn/csrc/CMakeFiles/sherpa-ncnn-core.dir/symbol-table.cc.o] Error 1
make[1]: *** [sherpa-ncnn/csrc/CMakeFiles/sherpa-ncnn-core.dir/all] Error 2
make: *** [all] Error 2

```