### PR TITLE
Update kaldi-native-fbank from 1.18.5 to 1.18.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 project(sherpa-ncnn)
 
-set(SHERPA_NCNN_VERSION "2.1.5")
+set(SHERPA_NCNN_VERSION "2.1.6")
 
 # Disable warning about
 #

--- a/cmake/kaldi-native-fbank.cmake
+++ b/cmake/kaldi-native-fbank.cmake
@@ -2,18 +2,18 @@ function(download_kaldi_native_fbank)
   include(FetchContent)
 
   # Please also change ../pack-for-embedded-systems.sh
-  set(kaldi_native_fbank_URL  "https://github.com/csukuangfj/kaldi-native-fbank/archive/refs/tags/v1.18.5.tar.gz")
-  set(kaldi_native_fbank_URL2 "https://huggingface.co/csukuangfj/sherpa-ncnn-cmake-deps/resolve/main/kaldi-native-fbank-1.18.5.tar.gz")
-  set(kaldi_native_fbank_HASH "SHA256=dce0cb3bc6fece5d8053d8780cb4ce22da57cb57ebec332641661521a0425283")
+  set(kaldi_native_fbank_URL  "https://github.com/csukuangfj/kaldi-native-fbank/archive/refs/tags/v1.18.6.tar.gz")
+  set(kaldi_native_fbank_URL2 "https://huggingface.co/csukuangfj/sherpa-ncnn-cmake-deps /resolve/main/kaldi-native-fbank-1.18.6.tar.gz")
+  set(kaldi_native_fbank_HASH "SHA256=6202a00cd06ba8ff89beb7b6f85cda34e073e94f25fc29e37c519bff0706bf19")
 
   # If you don't have access to the Internet, please download it to your
   # local drive and modify the following line according to your needs.
   set(possible_file_locations
-    $ENV{HOME}/Downloads/kaldi-native-fbank-1.18.5.tar.gz
-    $ENV{HOME}/asr/kaldi-native-fbank-1.18.5.tar.gz
-    ${PROJECT_SOURCE_DIR}/kaldi-native-fbank-1.18.5.tar.gz
-    ${PROJECT_BINARY_DIR}/kaldi-native-fbank-1.18.5.tar.gz
-    /tmp/kaldi-native-fbank-1.18.5.tar.gz
+    $ENV{HOME}/Downloads/kaldi-native-fbank-1.18.6.tar.gz
+    $ENV{HOME}/asr/kaldi-native-fbank-1.18.6.tar.gz
+    ${PROJECT_SOURCE_DIR}/kaldi-native-fbank-1.18.6.tar.gz
+    ${PROJECT_BINARY_DIR}/kaldi-native-fbank-1.18.6.tar.gz
+    /tmp/kaldi-native-fbank-1.18.6.tar.gz
   )
 
   foreach(f IN LISTS possible_file_locations)


### PR DESCRIPTION
The file size of the shared library of kaldi-native-fbank is reduced from 161KB to 113KB with this PR.

# Before this PR
```
-rwxr-xr-x  1 fangjun  staff   161K Oct 17 15:23 libkaldi-native-fbank-core.dylib
```

# With this PR
```
-rwxr-xr-x  1 fangjun  staff   113K Jan 12 17:27 libkaldi-native-fbank-core.dylib
```