### PR TITLE
Disable compressing asset files

### DIFF
--- a/android/SherpaNcnn/app/build.gradle
+++ b/android/SherpaNcnn/app/build.gradle
@@ -4,6 +4,10 @@ plugins {
 }
 
 android {
+    aaptOptions {
+        // https://google.github.io/android-gradle-dsl/3.3/com.android.build.gradle.internal.dsl.AaptOptions.html#com.android.build.gradle.internal.dsl.AaptOptions:noCompress
+        noCompress ''
+    }
     namespace 'com.k2fsa.sherpa.ncnn'
     compileSdk 32
 


### PR DESCRIPTION
See 
<img width="444" alt="Screenshot 2024-04-10 at 17 42 55" src="https://github.com/k2-fsa/sherpa-ncnn/assets/5284924/391cebc7-1d69-4561-9090-019907644f76">

<img width="441" alt="Screenshot 2024-04-10 at 17 43 05" src="https://github.com/k2-fsa/sherpa-ncnn/assets/5284924/152029bb-565a-4aa7-ba42-ee915240b9f6">

https://google.github.io/android-gradle-dsl/3.3/com.android.build.gradle.internal.dsl.AaptOptions.html#com.android.build.gradle.internal.dsl.AaptOptions:noCompress

---

It should fix #330 