### PR TITLE
Update wave-reader.cc

### DIFF
--- a/sherpa-ncnn/csrc/wave-reader.cc
+++ b/sherpa-ncnn/csrc/wave-reader.cc
@@ -19,6 +19,7 @@
 #include "sherpa-ncnn/csrc/wave-reader.h"
 
 #include <cassert>
+#include <cstdint>
 #include <fstream>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Fix gcc13.x and above, 'uint8_t' was not declared in this scope