### PR TITLE
Update cmake deps

### DIFF
--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -45,14 +45,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: arm-gnu-toolchain
+      - name: Install qemu
         run: |
           sudo apt-get update
           sudo apt-get install qemu-user-static
 
       - name: cache-toolchain
         id: cache-toolchain
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: toolchain
           key: gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf
@@ -74,10 +74,9 @@ jobs:
           export PATH=$GITHUB_WORKSPACE/toolchain/bin:$PATH
           arm-linux-gnueabihf-gcc --version
 
-      - name: Display qemu-arm -h
+      - name: Display qemu-arm-static -h
         shell: bash
         run: |
-          export PATH=$GITHUB_WORKSPACE/qemu-install/bin:$PATH
           export QEMU_LD_PREFIX=$GITHUB_WORKSPACE/toolchain/arm-linux-gnueabihf/libc
           qemu-arm-static -h
 

--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -45,34 +45,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: cache-qemu
-        id: cache-qemu
-        uses: actions/cache@v3
-        with:
-          path: qemu-install
-          key: qemu-arm-install-20220907
-
-      - name: install-qemu-build-deps
-        if: steps.cache-qemu.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install autoconf automake autotools-dev ninja-build
-
-      - name: checkout-qemu
-        if: steps.cache-qemu.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: qemu/qemu
-          path: qemu
-          ref: f5643914a9e8f79c606a76e6a9d7ea82a3fc3e65
-
-      - name: qemu
-        if: steps.cache-qemu.outputs.cache-hit != 'true'
-        run: |
-          cd qemu
-          ./configure --prefix=$GITHUB_WORKSPACE/qemu-install --target-list=arm-linux-user --disable-system
-          make -j2
-          make install
+    - name: arm-gnu-toolchain
+      run: |
+        sudo apt-get update
+        sudo apt-get install qemu-user-static
 
       - name: cache-toolchain
         id: cache-toolchain
@@ -103,7 +79,7 @@ jobs:
         run: |
           export PATH=$GITHUB_WORKSPACE/qemu-install/bin:$PATH
           export QEMU_LD_PREFIX=$GITHUB_WORKSPACE/toolchain/arm-linux-gnueabihf/libc
-          qemu-arm -h
+          qemu-arm-static -h
 
       - name: build arm-linux-gnueabihf
         shell: bash
@@ -124,7 +100,7 @@ jobs:
           export PATH=$GITHUB_WORKSPACE/qemu-install/bin:$PATH
           export QEMU_LD_PREFIX=$GITHUB_WORKSPACE/toolchain/arm-linux-gnueabihf/libc
 
-          export EXE="qemu-arm ./build-arm-linux-gnueabihf/bin/sherpa-ncnn"
+          export EXE="qemu-arm-static ./build-arm-linux-gnueabihf/bin/sherpa-ncnn"
 
           ls -lh ./build-arm-linux-gnueabihf/bin
 
@@ -137,7 +113,7 @@ jobs:
           export PATH=$GITHUB_WORKSPACE/qemu-install/bin:$PATH
           export QEMU_LD_PREFIX=$GITHUB_WORKSPACE/toolchain/arm-linux-gnueabihf/libc
 
-          export EXE="qemu-arm ./build-arm-linux-gnueabihf/bin/decode-file-c-api"
+          export EXE="qemu-arm-static ./build-arm-linux-gnueabihf/bin/decode-file-c-api"
 
           ls -lh ./build-arm-linux-gnueabihf/bin
 

--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -41,11 +41,11 @@ jobs:
         include:
           - vs-version: vs2015
             toolset-version: v140
-            os: windows-2019
+            os: windows-2022
 
           - vs-version: vs2017
             toolset-version: v141
-            os: windows-2019
+            os: windows-2022
 
           - vs-version: vs2019
             toolset-version: v142

--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -39,14 +39,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - vs-version: vs2015
-            toolset-version: v140
-            os: windows-2022
-
-          - vs-version: vs2017
-            toolset-version: v141
-            os: windows-2022
-
           - vs-version: vs2019
             toolset-version: v142
             os: windows-2022

--- a/.github/workflows/windows-x86.yaml
+++ b/.github/workflows/windows-x86.yaml
@@ -41,11 +41,11 @@ jobs:
         include:
           - vs-version: vs2015
             toolset-version: v140
-            os: windows-2019
+            os: windows-2022
 
           - vs-version: vs2017
             toolset-version: v141
-            os: windows-2019
+            os: windows-2022
 
           - vs-version: vs2019
             toolset-version: v142

--- a/.github/workflows/windows-x86.yaml
+++ b/.github/workflows/windows-x86.yaml
@@ -39,14 +39,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - vs-version: vs2015
-            toolset-version: v140
-            os: windows-2022
-
-          - vs-version: vs2017
-            toolset-version: v141
-            os: windows-2022
-
           - vs-version: vs2019
             toolset-version: v142
             os: windows-2022

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,11 @@ cmake-build-release
 cmake-build-debug
 
 node_modules
+*.ncnn.param
+*.ncnn.bin
+*.apk
+*.wav
+*.bak
+*-bak
+*.bin
+*.param

--- a/build-ios.sh
+++ b/build-ios.sh
@@ -181,11 +181,12 @@ libtool -static -o build/os64/sherpa-ncnn.a \
   build/os64/lib/libncnn.a \
   build/os64/lib/libsherpa-ncnn-c-api.a \
   build/os64/lib/libsherpa-ncnn-core.a \
-  build/os64/lib/libkaldi-native-fbank-core.a
+  build/os64/lib/libkaldi-native-fbank-core.a \
+  build/os64/lib/libkissfft-float.a
 
 mkdir -p "build/simulator/lib"
 
-for f in libncnn.a libsherpa-ncnn-c-api.a libsherpa-ncnn-core.a libkaldi-native-fbank-core.a; do
+for f in libncnn.a libsherpa-ncnn-c-api.a libsherpa-ncnn-core.a libkaldi-native-fbank-core.a libkissfft-float.a; do
   lipo -create build/simulator_arm64/lib/${f} \
                build/simulator_x86_64/lib/${f} \
        -output build/simulator/lib/${f}
@@ -197,7 +198,8 @@ libtool -static -o build/simulator/sherpa-ncnn.a \
   build/simulator/lib/libncnn.a \
   build/simulator/lib/libsherpa-ncnn-c-api.a \
   build/simulator/lib/libsherpa-ncnn-core.a \
-  build/simulator/lib/libkaldi-native-fbank-core.a
+  build/simulator/lib/libkaldi-native-fbank-core.a \
+  build/simulator/lib/libkissfft-float.a
 
 
 xcodebuild -create-xcframework \

--- a/build-swift-macos.sh
+++ b/build-swift-macos.sh
@@ -85,7 +85,8 @@ libtool -static -o ./build/install/lib/sherpa-ncnn.a \
   build/install/lib/libncnn.a \
   build/install/lib/libsherpa-ncnn-c-api.a \
   build/install/lib/libsherpa-ncnn-core.a \
-  build/install/lib/libkaldi-native-fbank-core.a
+  build/install/lib/libkaldi-native-fbank-core.a \
+  build/install/lib/libkissfft-float.a
 
 xcodebuild -create-xcframework \
       -library "build/install/lib/sherpa-ncnn.a" \

--- a/cmake/kaldi-native-fbank.cmake
+++ b/cmake/kaldi-native-fbank.cmake
@@ -46,9 +46,9 @@ function(download_kaldi_native_fbank)
 
   add_subdirectory(${kaldi_native_fbank_SOURCE_DIR} ${kaldi_native_fbank_BINARY_DIR} EXCLUDE_FROM_ALL)
   if(SHERPA_NCNN_ENABLE_PYTHON AND WIN32)
-    install(TARGETS kaldi-native-fbank-core DESTINATION ..)
+    install(TARGETS kaldi-native-fbank-core kissfft DESTINATION ..)
   else()
-    install(TARGETS kaldi-native-fbank-core DESTINATION lib)
+    install(TARGETS kaldi-native-fbank-core kissfft DESTINATION lib)
   endif()
 
   target_include_directories(kaldi-native-fbank-core

--- a/cmake/kaldi-native-fbank.cmake
+++ b/cmake/kaldi-native-fbank.cmake
@@ -2,18 +2,18 @@ function(download_kaldi_native_fbank)
   include(FetchContent)
 
   # Please also change ../pack-for-embedded-systems.sh
-  set(kaldi_native_fbank_URL  "https://github.com/csukuangfj/kaldi-native-fbank/archive/refs/tags/v1.18.7.tar.gz")
-  set(kaldi_native_fbank_URL2 "https://hub.nuaa.cf/csukuangfj/kaldi-native-fbank/archive/refs/tags/v1.18.7.tar.gz")
-  set(kaldi_native_fbank_HASH "SHA256=e78fd9d481d83d7d6d1be0012752e6531cb614e030558a3491e3c033cb8e0e4e")
+  set(kaldi_native_fbank_URL   "https://github.com/csukuangfj/kaldi-native-fbank/archive/refs/tags/v1.21.3.tar.gz")
+  set(kaldi_native_fbank_URL2  "https://hf-mirror.com/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/kaldi-native-fbank-1.21.3.tar.gz")
+  set(kaldi_native_fbank_HASH "SHA256=d409eddae5a46dc796f0841880f489ff0728b96ae26218702cd438c28667c70e")
 
   # If you don't have access to the Internet, please download it to your
   # local drive and modify the following line according to your needs.
   set(possible_file_locations
-    $ENV{HOME}/Downloads/kaldi-native-fbank-1.18.7.tar.gz
-    $ENV{HOME}/asr/kaldi-native-fbank-1.18.7.tar.gz
-    ${PROJECT_SOURCE_DIR}/kaldi-native-fbank-1.18.7.tar.gz
-    ${PROJECT_BINARY_DIR}/kaldi-native-fbank-1.18.7.tar.gz
-    /tmp/kaldi-native-fbank-1.18.7.tar.gz
+    $ENV{HOME}/Downloads/kaldi-native-fbank-1.21.3.tar.gz
+    $ENV{HOME}/asr/kaldi-native-fbank-1.21.3.tar.gz
+    ${PROJECT_SOURCE_DIR}/kaldi-native-fbank-1.21.3.tar.gz
+    ${PROJECT_BINARY_DIR}/kaldi-native-fbank-1.21.3.tar.gz
+    /tmp/kaldi-native-fbank-1.21.3.tar.gz
   )
 
   foreach(f IN LISTS possible_file_locations)

--- a/cmake/ncnn.cmake
+++ b/cmake/ncnn.cmake
@@ -7,19 +7,19 @@ function(download_ncnn)
 
   # Please also change ../pack-for-embedded-systems.sh
 
-  # the latest master as of 2025.05.19
-  set(ncnn_URL  "https://github.com/Tencent/ncnn/archive/6fa649f1034950dbad84596abb8c2a375e581fff.zip")
-  set(ncnn_URL2 "https://huggingface.co/csukuangfj/sherpa-ncnn-cmake-deps/resolve/main/ncnn-6fa649f1034950dbad84596abb8c2a375e581fff.zip")
-  set(ncnn_HASH "SHA256=0b0540b4a8ca73430c2cea610c2e2dfc92729dc270a4f049f8b6ba2bf96bde7d")
+  # the latest master as of 2025.08.15
+  set(ncnn_URL  "https://github.com/Tencent/ncnn/archive/d68ea6b4d551bbdc3781f68fd4bb1e1b87a4eb1d.zip")
+  set(ncnn_URL2 "https://huggingface.co/csukuangfj/sherpa-ncnn-cmake-deps/resolve/main/ncnn-d68ea6b4d551bbdc3781f68fd4bb1e1b87a4eb1d.zip")
+  set(ncnn_HASH "SHA256=e8da29e36e202af821511160a41bb0e1dc5d8c85a07b87e82b790f8239e5bfec")
 
   # If you don't have access to the Internet, please download it to your
   # local drive and modify the following line according to your needs.
   set(possible_file_locations
-    $ENV{HOME}/Downloads/ncnn-6fa649f1034950dbad84596abb8c2a375e581fff.zip
-    $ENV{HOME}/asr/ncnn-6fa649f1034950dbad84596abb8c2a375e581fff.zip
-    ${PROJECT_SOURCE_DIR}/ncnn-6fa649f1034950dbad84596abb8c2a375e581fff.zip
-    ${PROJECT_BINARY_DIR}/ncnn-6fa649f1034950dbad84596abb8c2a375e581fff.zip
-    /tmp/ncnn-6fa649f1034950dbad84596abb8c2a375e581fff.zip
+    $ENV{HOME}/Downloads/ncnn-d68ea6b4d551bbdc3781f68fd4bb1e1b87a4eb1d.zip
+    $ENV{HOME}/asr/ncnn-d68ea6b4d551bbdc3781f68fd4bb1e1b87a4eb1d.zip
+    ${PROJECT_SOURCE_DIR}/ncnn-d68ea6b4d551bbdc3781f68fd4bb1e1b87a4eb1d.zip
+    ${PROJECT_BINARY_DIR}/ncnn-d68ea6b4d551bbdc3781f68fd4bb1e1b87a4eb1d.zip
+    /tmp/ncnn-d68ea6b4d551bbdc3781f68fd4bb1e1b87a4eb1d.zip
   )
 
   foreach(f IN LISTS possible_file_locations)
@@ -178,6 +178,7 @@ function(download_ncnn)
     RelPositionalEncoding
     MakePadMask
     RelShift
+    # Flip
   )
 
   foreach(layer IN LISTS disabled_layers)

--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -1,18 +1,18 @@
 function(download_pybind11)
   include(FetchContent)
 
-  set(pybind11_URL  "https://github.com/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz")
-  set(pybind11_URL2 "https://hub.nuaa.cf/pybind/pybind11/archive/refs/tags/v2.10.2.tar.gz")
-  set(pybind11_HASH "SHA256=93bd1e625e43e03028a3ea7389bba5d3f9f2596abc074b068e70f4ef9b1314ae")
+  set(pybind11_URL  "https://github.com/pybind/pybind11/archive/refs/tags/v2.12.0.tar.gz")
+  set(pybind11_URL2 "https://hf-mirror.com/csukuangfj/sherpa-onnx-cmake-deps/resolve/main/pybind11-2.12.0.tar.gz")
+  set(pybind11_HASH "SHA256=bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7")
 
   # If you don't have access to the Internet, please download it to your
   # local drive and modify the following line according to your needs.
   set(possible_file_locations
-    $ENV{HOME}/Downloads/pybind11-2.10.2.tar.gz
-    $ENV{HOME}/asr/pybind11-2.10.2.tar.gz
-    ${PROJECT_SOURCE_DIR}/pybind11-2.10.2.tar.gz
-    ${PROJECT_BINARY_DIR}/pybind11-2.10.2.tar.gz
-    /tmp/pybind11-2.10.2.tar.gz
+    $ENV{HOME}/Downloads/pybind11-2.12.0.tar.gz
+    $ENV{HOME}/asr/pybind11-2.12.0.tar.gz
+    ${PROJECT_SOURCE_DIR}/pybind11-2.12.0.tar.gz
+    ${PROJECT_BINARY_DIR}/pybind11-2.12.0.tar.gz
+    /tmp/pybind11-2.12.0.tar.gz
   )
 
   foreach(f IN LISTS possible_file_locations)

--- a/cmake/sherpa-ncnn.pc.in
+++ b/cmake/sherpa-ncnn.pc.in
@@ -9,4 +9,4 @@ URL: https://github.com/k2-fsa/sherpa-ncnn
 
 Version: @SHERPA_NCNN_VERSION@
 Cflags: -I"${includedir}"
-Libs: -L"${libdir}" -lsherpa-ncnn-c-api -lsherpa-ncnn-core -lncnn -lkaldi-native-fbank-core -Wl,-rpath,${libdir} @SHERPA_NCNN_PKG_CONFIG_EXTRA_LIBS@
+Libs: -L"${libdir}" -lsherpa-ncnn-c-api -lsherpa-ncnn-core -lncnn -lkaldi-native-fbank-core -lkissfft-float -Wl,-rpath,${libdir} @SHERPA_NCNN_PKG_CONFIG_EXTRA_LIBS@

--- a/mfc-examples/RealtimeSpeechRecognition/sherpa-ncnn-deps.props
+++ b/mfc-examples/RealtimeSpeechRecognition/sherpa-ncnn-deps.props
@@ -10,6 +10,7 @@
 	  sherpa-ncnn-c-api.lib;;
 	  sherpa-ncnn-core.lib;
 	  kaldi-native-fbank-core.lib;
+	  kissfft-float.lib;
 	  ncnn.lib
 	</SherpaNcnnLibraries>
   </PropertyGroup>

--- a/scripts/dotnet/generate.py
+++ b/scripts/dotnet/generate.py
@@ -33,6 +33,7 @@ def get_dict():
 
 def process_linux(s):
     libs = [
+        "libkissfft-float.so",
         "libkaldi-native-fbank-core.so",
         "libncnn.so",
         "libsherpa-ncnn-c-api.so",
@@ -56,6 +57,7 @@ def process_linux(s):
 
 def process_macos(s):
     libs = [
+        "libkissfft-float.dylib",
         "libkaldi-native-fbank-core.dylib",
         "libncnn.dylib",
         "libsherpa-ncnn-c-api.dylib",
@@ -78,6 +80,7 @@ def process_macos(s):
 
 def process_windows(s):
     libs = [
+        "kissfft-float.dll",
         "kaldi-native-fbank-core.dll",
         "ncnn.dll",
         "sherpa-ncnn-c-api.dll",

--- a/scripts/go/release.sh
+++ b/scripts/go/release.sh
@@ -16,6 +16,7 @@ echo "Copy libs for Linux x86_64"
 rm -rf sherpa-ncnn-go-linux/lib/x86_64-unknown-linux-gnu/lib*
 
 cp -v ./linux_x86_64/sherpa_ncnn/lib/libkaldi-native-fbank-core.so sherpa-ncnn-go-linux/lib/x86_64-unknown-linux-gnu/
+cp -v ./linux_x86_64/sherpa_ncnn/lib/libkissfft-float.so sherpa-ncnn-go-linux/lib/x86_64-unknown-linux-gnu/
 cp -v ./linux_x86_64/sherpa_ncnn/lib/libncnn.so sherpa-ncnn-go-linux/lib/x86_64-unknown-linux-gnu/
 cp -v ./linux_x86_64/sherpa_ncnn/lib/libsherpa-ncnn-c-api.so sherpa-ncnn-go-linux/lib/x86_64-unknown-linux-gnu/
 cp -v ./linux_x86_64/sherpa_ncnn/lib/libsherpa-ncnn-core.so sherpa-ncnn-go-linux/lib/x86_64-unknown-linux-gnu/
@@ -26,6 +27,7 @@ echo "Copy libs for Linux aarch64"
 rm -rf sherpa-ncnn-go-linux/lib/aarch64-unknown-linux-gnu/lib*
 
 cp -v ./linux_aarch64/sherpa_ncnn/lib/libkaldi-native-fbank-core.so sherpa-ncnn-go-linux/lib/aarch64-unknown-linux-gnu/
+cp -v ./linux_aarch64/sherpa_ncnn/lib/libkissfft-float.so sherpa-ncnn-go-linux/lib/aarch64-unknown-linux-gnu/
 cp -v ./linux_aarch64/sherpa_ncnn/lib/libncnn.so sherpa-ncnn-go-linux/lib/aarch64-unknown-linux-gnu/
 cp -v ./linux_aarch64/sherpa_ncnn/lib/libsherpa-ncnn-c-api.so sherpa-ncnn-go-linux/lib/aarch64-unknown-linux-gnu/
 cp -v ./linux_aarch64/sherpa_ncnn/lib/libsherpa-ncnn-core.so sherpa-ncnn-go-linux/lib/aarch64-unknown-linux-gnu/
@@ -67,6 +69,7 @@ git clone git@github.com:k2-fsa/sherpa-ncnn-go-macos.git
 echo "Copy libs for macOS x86_64"
 rm -rf sherpa-ncnn-go-macos/lib/x86_64-apple-darwin/lib*
 cp -v ./macos-x86_64/libkaldi-native-fbank-core.dylib sherpa-ncnn-go-macos/lib/x86_64-apple-darwin
+cp -v ./macos-x86_64/libkissfft-float.dylib sherpa-ncnn-go-macos/lib/x86_64-apple-darwin
 cp -v ./macos-x86_64/libncnn.dylib sherpa-ncnn-go-macos/lib/x86_64-apple-darwin
 cp -v ./macos-x86_64/libsherpa-ncnn-c-api.dylib sherpa-ncnn-go-macos/lib/x86_64-apple-darwin
 cp -v ./macos-x86_64/libsherpa-ncnn-core.dylib sherpa-ncnn-go-macos/lib/x86_64-apple-darwin
@@ -74,6 +77,7 @@ cp -v ./macos-x86_64/libsherpa-ncnn-core.dylib sherpa-ncnn-go-macos/lib/x86_64-a
 echo "Copy libs for macOS arm64"
 rm -rf sherpa-ncnn-go-macos/lib/aarch64-apple-darwin/lib*
 cp -v ./macos-arm64/libkaldi-native-fbank-core.dylib sherpa-ncnn-go-macos/lib/aarch64-apple-darwin
+cp -v ./macos-arm64/libkissfft-float.dylib sherpa-ncnn-go-macos/lib/aarch64-apple-darwin
 cp -v ./macos-arm64/libncnn.dylib sherpa-ncnn-go-macos/lib/aarch64-apple-darwin
 cp -v ./macos-arm64/libsherpa-ncnn-c-api.dylib sherpa-ncnn-go-macos/lib/aarch64-apple-darwin
 cp -v ./macos-arm64/libsherpa-ncnn-core.dylib sherpa-ncnn-go-macos/lib/aarch64-apple-darwin
@@ -113,6 +117,7 @@ git clone git@github.com:k2-fsa/sherpa-ncnn-go-windows.git
 echo "Copy libs for Windows x86_64"
 rm -fv sherpa-ncnn-go-windows/lib/x86_64-pc-windows-gnu/*
 cp -v ./windows-x64/kaldi-native-fbank-core.dll sherpa-ncnn-go-windows/lib/x86_64-pc-windows-gnu
+cp -v ./windows-x64/kissfft-float.dll sherpa-ncnn-go-windows/lib/x86_64-pc-windows-gnu
 cp -v ./windows-x64/ncnn.dll sherpa-ncnn-go-windows/lib/x86_64-pc-windows-gnu
 cp -v ./windows-x64/sherpa-ncnn-c-api.dll sherpa-ncnn-go-windows/lib/x86_64-pc-windows-gnu
 cp -v ./windows-x64/sherpa-ncnn-core.dll sherpa-ncnn-go-windows/lib/x86_64-pc-windows-gnu
@@ -120,6 +125,7 @@ cp -v ./windows-x64/sherpa-ncnn-core.dll sherpa-ncnn-go-windows/lib/x86_64-pc-wi
 echo "Copy libs for Windows x86"
 rm -fv sherpa-ncnn-go-windows/lib/i686-pc-windows-gnu/*
 cp -v ./windows-win32/kaldi-native-fbank-core.dll sherpa-ncnn-go-windows/lib/i686-pc-windows-gnu
+cp -v ./windows-win32/kissfft-float.dll sherpa-ncnn-go-windows/lib/i686-pc-windows-gnu
 cp -v ./windows-win32/ncnn.dll sherpa-ncnn-go-windows/lib/i686-pc-windows-gnu
 cp -v ./windows-win32/sherpa-ncnn-c-api.dll sherpa-ncnn-go-windows/lib/i686-pc-windows-gnu
 cp -v ./windows-win32/sherpa-ncnn-core.dll sherpa-ncnn-go-windows/lib/i686-pc-windows-gnu


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added kissfft-float across platforms and tooling: iOS (device/simulator), macOS static libs, pkg-config, Windows/MFC example, .NET generation, and Go release bundles.
  * Upgraded dependencies: kaldi-native-fbank → v1.21.3, ncnn → 2025-08-15 snapshot, pybind11 → v2.12.0.
  * Expanded .gitignore to ignore additional artifacts (.apk, .wav, backups, ncnn param/bin, generic .bin/.param).
  * CI/workflow updates: simplified ARM QEMU/toolchain handling; Windows workflows now target Windows-2022.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->