### PR TITLE
fix(windows): support GB2312 input text for offline TTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ endif()
 include(kaldi-native-fbank)
 include(kaldifst)
 include(ncnn)
+include(json)
 
 if(SHERPA_NCNN_ENABLE_PORTAUDIO)
   include(portaudio)

--- a/sherpa-ncnn/csrc/offline-tts.cc
+++ b/sherpa-ncnn/csrc/offline-tts.cc
@@ -167,17 +167,19 @@ GeneratedAudio OfflineTts::Generate(
 #if !defined(_WIN32)
   return impl_->Generate(args, std::move(callback), callback_arg);
 #else
-  if (IsUtf8(text)) {
+  if (IsUtf8(args.text)) {
     return impl_->Generate(args, std::move(callback), callback_arg);
-  } else if (IsGB2312(text)) {
-    auto utf8_text = Gb2312ToUtf8(text);
+  } else if (IsGB2312(args.text)) {
+    auto utf8_text = Gb2312ToUtf8(args.text);
     static bool printed = false;
     if (!printed) {
       SHERPA_NCNN_LOGE(
           "Detected GB2312 encoded string! Converting it to UTF8.");
       printed = true;
     }
-    return impl_->Generate(args, std::move(callback), callback_arg);
+    TtsArgs utf8_args = args;
+    utf8_args.text = utf8_text;
+    return impl_->Generate(utf8_args, std::move(callback), callback_arg);
   } else {
     SHERPA_NCNN_LOGE(
         "Non UTF8 encoded string is received. You would not get expected "

--- a/sherpa-ncnn/csrc/text-utils.cc
+++ b/sherpa-ncnn/csrc/text-utils.cc
@@ -669,7 +669,7 @@ std::string Gb2312ToUtf8(const std::string &text) {
 
   std::wstring wstr;
   wstr.resize(num_wchars);
-  MultiByteToWideChar(936, 0, text.c_str(), text.size(), wstr.data(),
+  MultiByteToWideChar(936, 0, text.c_str(), text.size(), &wstr[0],
                       num_wchars);
   // https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
   int32_t num_chars = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr,
@@ -679,7 +679,7 @@ std::string Gb2312ToUtf8(const std::string &text) {
   }
 
   std::string ans(num_chars, 0);
-  WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, ans.data(), num_chars,
+  WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, &ans[0], num_chars,
                       nullptr, nullptr);
 
   return ans;


### PR DESCRIPTION
- Fixed `OfflineTts::Generate` to properly detect and convert GB2312-encoded input (`args.text`) into UTF-8 before passing to implementation.
- Updated `text-utils.cc` to use `&wstr[0]` and `&ans[0]` in Windows API calls (`MultiByteToWideChar`, `WideCharToMultiByte`) to ensure correct buffer handling.
- Added `json` to CMake includes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Windows: Text-to-speech now accepts GB2312-encoded input by auto-converting it to UTF-8.

- Bug Fixes
  - Reduced errors when processing non-UTF-8 text in Windows text-to-speech.
  - Improved reliability of text encoding conversion on Windows.

- Chores
  - Added JSON support to the build configuration to enable related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->