### PR TITLE
fix android compilation erros

### DIFF
--- a/build-android-x86.sh
+++ b/build-android-x86.sh
@@ -55,6 +55,6 @@ cmake -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" 
     -DSHERPA_NCNN_ENABLE_GENERATE_INT8_SCALE_TABLE=OFF \
     -DCMAKE_INSTALL_PREFIX=./install \
     -DANDROID_ABI="x86" \
-    -DANDROID_PLATFORM=android-14 ..
+    -DANDROID_PLATFORM=android-21 ..
 make VERBOSE=1 -j4
 make install/strip


### PR DESCRIPTION
keep consistend with oher android arch builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android platform API level from 14 to 21 in build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->